### PR TITLE
Added support for YARN scaling

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -25,7 +25,7 @@ install: gen-server install-torch
 
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve NousResearch/Yarn-Mistral-7b-128k --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve alexsherstinsky/Mistral-7B-v0.1-sharded --sharded
 
 export-requirements:

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -550,10 +550,12 @@ try:
             scaling_factor = None
             rope_scaling = _get_rope_config(config)
             if rope_scaling is not None:
+                rope_scaling = rope_scaling.copy()
                 scaling_factor = rope_scaling["factor"]
-                if rope_scaling["type"] == "linear":
+                rope_type = rope_scaling.pop("type")
+                if rope_type == "linear":
                     pass
-                elif rope_scaling["type"] == "dynamic":
+                elif rope_type == "dynamic":
                     return DynamicPositionRotaryEmbedding(
                         dim=dim,
                         max_position_embeddings=config.max_position_embeddings,
@@ -561,9 +563,17 @@ try:
                         device=inv_freq.device,
                         scaling_factor=scaling_factor,
                     )
+                elif rope_type == "yarn":
+                    return YarnPositionRotaryEmbedding(
+                        dim=dim,
+                        max_position_embeddings=config.max_position_embeddings,
+                        base=base,
+                        device=inv_freq.device,
+                        **rope_scaling,
+                    )
                 else:
                     raise NotImplementedError(
-                        f"rope scaling type {rope_scaling['type']} is not implemented or invalid"
+                        f"rope scaling type {rope_type} is not implemented or invalid"
                     )
             return cls(inv_freq, scaling_factor)
 
@@ -578,10 +588,12 @@ try:
             scaling_factor = None
             rope_scaling = _get_rope_config(config)
             if rope_scaling is not None:
+                rope_scaling = rope_scaling.copy()
                 scaling_factor = rope_scaling["factor"]
-                if rope_scaling["type"] == "linear":
+                rope_type = rope_scaling.pop("type")
+                if rope_type == "linear":
                     pass
-                elif rope_scaling["type"] == "dynamic":
+                elif rope_type == "dynamic":
                     return DynamicPositionRotaryEmbedding(
                         dim=2 * inv_freq.shape[0],
                         max_position_embeddings=config.max_position_embeddings,
@@ -589,9 +601,17 @@ try:
                         device=inv_freq.device,
                         scaling_factor=scaling_factor,
                     )
+                elif rope_type == "yarn":
+                    return YarnPositionRotaryEmbedding(
+                        dim=2 * inv_freq.shape[0],
+                        max_position_embeddings=config.max_position_embeddings,
+                        base=10000.0,
+                        device=inv_freq.device,
+                        **rope_scaling,
+                    )
                 else:
                     raise NotImplementedError(
-                        f"rope scaling type {rope_scaling['type']} is not implemented or invalid"
+                        f"rope scaling type {rope_type} is not implemented or invalid"
                     )
             return cls(inv_freq, scaling_factor)
 

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -727,12 +727,10 @@ try:
                 self._seq_len_cached = seqlen
 
                 t = torch.arange(self._seq_len_cached, device=device, dtype=self.inv_freq.dtype)
-                freqs = torch.einsum("i,j->ij", t, self.inv_freq)
-                # Different from paper, but it uses a different permutation in order to obtain the same calculation
-                emb = torch.cat((freqs, freqs), dim=-1).to(device)
+                freqs = torch.outer(t, self.inv_freq.to(device=t.device))
 
-                self._cos_cached = (emb.cos() * self.mscale)[None, None, :, :].to(dtype)
-                self._sin_cached = (emb.sin() * self.mscale)[None, None, :, :].to(dtype)
+                self._cos_cached = (torch.cos(freqs) * self.mscale).to(dtype)
+                self._sin_cached = (torch.sin(freqs) * self.mscale).to(dtype)
         
         def yarn(self, device):
             pos_freqs = self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim)


### PR DESCRIPTION
Following implementation from https://github.com/jquesnelle/yarn/blob/master/scaled_rope/LlamaYaRNScaledRotaryEmbedding.py

Example model: https://huggingface.co/NousResearch/Yarn-Mistral-7b-128k