### PR TITLE
Fixed tensor parallelism splits

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -24,8 +24,8 @@ install: gen-server install-torch
 	pip install -e ".[bnb, accelerate]"
 
 run-dev:
-	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
+	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve alexsherstinsky/Mistral-7B-v0.1-sharded --sharded
 
 export-requirements:

--- a/server/Makefile
+++ b/server/Makefile
@@ -25,7 +25,7 @@ install: gen-server install-torch
 
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve NousResearch/Yarn-Mistral-7b-128k --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve alexsherstinsky/Mistral-7B-v0.1-sharded --sharded
 
 export-requirements:

--- a/server/Makefile
+++ b/server/Makefile
@@ -24,8 +24,8 @@ install: gen-server install-torch
 	pip install -e ".[bnb, accelerate]"
 
 run-dev:
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve alexsherstinsky/Mistral-7B-v0.1-sharded --sharded
 
 export-requirements:

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -790,6 +790,9 @@ class FlashCausalLM(Model):
         
         prefix = "model.layers"
         for i, layer in enumerate(self.model.model.layers):
+            # TODO(travis): generalize this beyond qkv for accessing the layer_id
+            # This works for o_proj because they share the same id sequence, but may not
+            # extend to other layers.
             layer = layer.self_attn.query_key_value
             base_weight = layer.base_layer.linear.weight
             base_device = base_weight.device

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -731,6 +731,15 @@ class FlashCausalLM(Model):
             sliding_window=sliding_window,
         )
 
+        weight_names = []
+        prefix = "model.layers"
+        for i, layer in enumerate(self.model.model.layers):
+            weight_names.append(f"{prefix}.{i}.self_attn.{Q_PROJ}")
+            weight_names.append(f"{prefix}.{i}.self_attn.{K_PROJ}")
+            weight_names.append(f"{prefix}.{i}.self_attn.{V_PROJ}")
+            weight_names.append(f"{prefix}.{i}.self_attn.{O_PROJ}")
+        self.weight_names = tuple(weight_names)
+
     @property
     def supports_adapter_loading(self) -> bool:
         return False
@@ -759,8 +768,7 @@ class FlashCausalLM(Model):
             return
         elif adapter_id != BASE_MODEL_ADAPTER_ID:
             logger.info(f"Loading adapter weights into model: {adapter_id}")
-            weight_names = tuple(self.orig_weights.keys())
-            module_map, adapter_config = load_module_map(self.model_id, adapter_id, adapter_source, weight_names)
+            module_map, adapter_config = load_module_map(self.model_id, adapter_id, adapter_source, self.weight_names)
 
             self.load_batched_adapter_weights(module_map, adapter_config, adapter_index, Q_PROJ)
             self.load_batched_adapter_weights(module_map, adapter_config, adapter_index, V_PROJ)
@@ -797,7 +805,7 @@ class FlashCausalLM(Model):
             lora_a_list[layer.layer_id] = lora_a.transpose(0, 1)
             lora_b_list[layer.layer_id] = lora_b.transpose(0, 1)
 
-        q_lora_merged = MergedLoraWeights(lora_a_list, lora_b_list, adapter_config, self.process_group)
+        q_lora_merged = MergedLoraWeights(lora_a_list, lora_b_list, adapter_config, layer_type, self.process_group)
         q_lora_weights = self.batched_lora_weights[layer_type]
         q_lora_weights.add_adapter(adapter_index, q_lora_merged)
     

--- a/server/lorax_server/models/flash_llama.py
+++ b/server/lorax_server/models/flash_llama.py
@@ -112,25 +112,6 @@ class FlashLlama(FlashCausalLM):
             rank=rank,
             world_size=world_size,
         )
-
-        # holds the original weights and the devices they were on as a tuple
-        # the original weights are stored in CPU memory, but placed into `device`
-        # as needed. Only needed when dynamic_adapter_loading_enabled is True.
-        self.orig_weights = None
-        if self.dynamic_adapter_loading_enabled:
-            # TODO(geoffrey): generalize to non-q_proj and non-v_proj layers
-            self.orig_weights = {}
-            prefix = "model.layers"
-            for i, layer in enumerate(self.model.model.layers):
-                q_proj, _, v_proj = layer.self_attn.get_query_key_value_weights(clone=True)
-
-                orig_q_proj_device = q_proj.device
-                weight_name = f"{prefix}.{i}.self_attn.q_proj"
-                self.orig_weights[weight_name] = (q_proj.cpu(), orig_q_proj_device)
-                
-                orig_v_proj_device = v_proj.device
-                weight_name = f"{prefix}.{i}.self_attn.v_proj"
-                self.orig_weights[weight_name] = (v_proj.cpu(), orig_v_proj_device)
     
     @property
     def supports_adapter_loading(self) -> bool:

--- a/server/lorax_server/models/flash_mistral.py
+++ b/server/lorax_server/models/flash_mistral.py
@@ -393,25 +393,6 @@ class FlashMistral(FlashCausalLM):
             sliding_window=config.sliding_window,
         )
 
-        # holds the original weights and the devices they were on as a tuple
-        # the original weights are stored in CPU memory, but placed into `device`
-        # as needed. Only needed when dynamic_adapter_loading_enabled is True.
-        self.orig_weights = None
-        if self.dynamic_adapter_loading_enabled:
-            # TODO(geoffrey): generalize to non-q_proj and non-v_proj layers
-            self.orig_weights = {}
-            prefix = "model.layers"
-            for i, layer in enumerate(self.model.model.layers):
-                q_proj, _, v_proj = layer.self_attn.get_query_key_value_weights(clone=True)
-
-                orig_q_proj_device = q_proj.device
-                weight_name = f"{prefix}.{i}.self_attn.q_proj"
-                self.orig_weights[weight_name] = (q_proj.cpu(), orig_q_proj_device)
-                
-                orig_v_proj_device = v_proj.device
-                weight_name = f"{prefix}.{i}.self_attn.v_proj"
-                self.orig_weights[weight_name] = (v_proj.cpu(), orig_v_proj_device)
-
     @property
     def supports_adapter_loading(self) -> bool:
         return True

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -39,9 +39,14 @@ def load_module_map(model_id, adapter_id, adapter_source, weight_names):
     # map the model weights to the relevant adapter weights (LoRA A and B matrices)
     module_map = {}
     for weight_name in weight_names:
+        lora_a_name = f"base_model.model.{weight_name}.lora_A.weight"
+        lora_b_name = f"base_model.model.{weight_name}.lora_B.weight"
+        if lora_a_name not in adapter_weights or lora_b_name not in adapter_weights:
+            continue
+        
         module_map[weight_name] = {
-            "lora_A": adapter_weights[f"base_model.model.{weight_name}.lora_A.weight"],
-            "lora_B": adapter_weights[f"base_model.model.{weight_name}.lora_B.weight"],
+            "lora_A": adapter_weights[lora_a_name],
+            "lora_B": adapter_weights[lora_b_name],
         }
     return module_map, adapter_config
 

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -322,8 +322,8 @@ class TensorParallelAdapterLinear(nn.Module):
             for adapter_index in adapter_data.meta.adapter_set:
                 if data is not None and data.has_adapter(adapter_index):
                     adapter_mask = (adapter_data.meta.adapter_indices == adapter_index).to(input.dtype).view(-1, 1)
-                    result = self.forward_lora(input, data, adapter_index, adapter_mask)
-                    result[:, start_idx:end_idx] += result
+                    layer_result = self.forward_lora(input, data, adapter_index, adapter_mask)
+                    result[:, start_idx:end_idx] += layer_result
 
         return result
     

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -336,18 +336,15 @@ class TensorParallelAdapterLinear(nn.Module):
     ) -> torch.Tensor:
         scaling = data.scaling_for_adapter(adapter_index)
 
-        try:
-            lora_a = data.lora_a[adapter_index][self.layer_id, :, :]
-            a_out = input @ lora_a
+        lora_a = data.lora_a[adapter_index][self.layer_id, :, :]
+        a_out = input @ lora_a
 
-            if self.process_group.size() > 1:
-                a_out = self.collect_lora_a(a_out)
-            
-            lora_b = data.lora_b[adapter_index][self.layer_id, :, :]
-            result = (a_out @ lora_b) * scaling * adapter_mask
-            return result
-        except Exception as e:
-            raise RuntimeError(f"adapter_mask={adapter_mask.shape}, input={input.shape}, lora_a={lora_a.shape}, lora_b={lora_b.shape}") from e
+        if self.process_group.size() > 1:
+            a_out = self.collect_lora_a(a_out)
+        
+        lora_b = data.lora_b[adapter_index][self.layer_id, :, :]
+        result = (a_out @ lora_b) * scaling * adapter_mask
+        return result
 
     def collect_lora_a(self, a_out: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError("Implemented in subclasses")
@@ -395,7 +392,13 @@ class TensorParallelAdapterRowLinear(TensorParallelAdapterLinear):
     
     def forward(self, input: torch.Tensor, adapter_data: AdapterBatchData) -> torch.Tensor:
         result = self.base_layer(input)
-        self.forward_layer_type(result, input, adapter_data, O_PROJ, 0, result.shape[-1])
+        
+        # Fused all-gather + all-reduce from S-LoRA paper: https://arxiv.org/abs/2311.03285
+        stride = result.shape[-1] // self.process_group.size()
+        start_idx = self.process_group.rank() * stride
+        end_idx = (self.process_group.rank() + 1) * stride
+        
+        self.forward_layer_type(result, input, adapter_data, O_PROJ, start_idx, end_idx)
         return result
     
     def collect_lora_a(self, a_out: torch.Tensor) -> torch.Tensor:

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -93,11 +93,11 @@ class MergedLoraWeights:
         process_group: ProcessGroup,
     ):
         # [num_layers, hidden_size, r]
-        weights_a = [shard_on_dim(w, dim=0, process_group=process_group) for w in weights_a]
+        weights_a = [shard_on_dim(w, dim=1, process_group=process_group) for w in weights_a]
         self.weights_a = torch.stack(weights_a)
 
         # [num_layers, r, hidden_size]
-        weights_a = [shard_on_dim(w, dim=0, process_group=process_group) for w in weights_b]
+        weights_b = [shard_on_dim(w, dim=1, process_group=process_group) for w in weights_b]
         self.weights_b = torch.stack(weights_b)
 
         self.adapter_config = adapter_config

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -14,6 +14,8 @@ K_PROJ = "k_proj"
 V_PROJ = "v_proj"
 O_PROJ = "o_proj"
 
+ROW_PARALLEL = {O_PROJ}
+
 
 EMPTY_TENSOR = torch.tensor([])
 
@@ -90,10 +92,12 @@ class MergedLoraWeights:
         weights_a: List[torch.Tensor],
         weights_b: List[torch.Tensor],
         adapter_config: LoraConfig,
+        layer_type: str,
         process_group: ProcessGroup,
     ):
         # [num_layers, hidden_size, r]
-        weights_a = [shard_on_dim(w, dim=1, process_group=process_group) for w in weights_a]
+        split_dim = 0 if layer_type in ROW_PARALLEL else 1
+        weights_a = [shard_on_dim(w, dim=split_dim, process_group=process_group) for w in weights_a]
         self.weights_a = torch.stack(weights_a)
 
         # [num_layers, r, hidden_size]


### PR DESCRIPTION
After removing the layer abstraction over the LoRA weights, we introduced a transpose operation, which meant we needed to be splitting on dim=1 rather than dim=0. This was causing tensor parallelism to break, affecting all deployments with more than one GPU.

This PR also fixes support for o_proj, which is row-parallel and needs to be split on dim=0. Previously, there was a bug preventing k_proj and o_proj from being picked up correctly, which is why this was missed.

Closes #46.