### PR TITLE
Add DISABLE_SGMV env var to explicitly fallback to loop

### DIFF
--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -20,7 +20,7 @@ from accelerate import init_empty_weights
 
 try:
     from lorax_server.utils.sgmv import add_lora_sgmv_cutlass
-    HAS_SGMV = bool(os.environ.get("DISABLE_SGMV", ""))
+    HAS_SGMV = not bool(os.environ.get("DISABLE_SGMV", ""))
 except ImportError:
     warnings.warn("Could not import SGMV kernel from Punica, falling back to loop.")
     HAS_SGMV = False

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -20,7 +20,7 @@ from accelerate import init_empty_weights
 
 try:
     from lorax_server.utils.sgmv import add_lora_sgmv_cutlass
-    HAS_SGMV = True
+    HAS_SGMV = bool(os.environ.get("DISABLE_SGMV", ""))
 except ImportError:
     warnings.warn("Could not import SGMV kernel from Punica, falling back to loop.")
     HAS_SGMV = False


### PR DESCRIPTION
SGMV kernel is still somewhat experimental. There are some cases (particular ranks, etc.) that can result in erroneous output. Until these issues are fully resolved, this escape hatch will allow users to fallback to the slower but correct loop implementation.

Example:

```
DISABLE_SGMV=1
```