### PR TITLE
Implement tensor parallel SGMV

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -25,8 +25,8 @@ install: gen-server install-torch
 
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve flozi00/Mistral-7B-german-assistant-v5-4bit-autogptq --quantize gptq
 
 export-requirements:

--- a/server/Makefile
+++ b/server/Makefile
@@ -25,8 +25,8 @@ install: gen-server install-torch
 
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve flozi00/Mistral-7B-german-assistant-v5-4bit-autogptq --quantize gptq
 
 export-requirements:

--- a/server/Makefile
+++ b/server/Makefile
@@ -26,7 +26,7 @@ install: gen-server install-torch
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve flozi00/Mistral-7B-german-assistant-v5-4bit-autogptq --quantize gptq
 
 export-requirements:

--- a/server/Makefile
+++ b/server/Makefile
@@ -25,8 +25,8 @@ install: gen-server install-torch
 
 run-dev:
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve meta-llama/Llama-2-7b-hf --sharded
-	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
-	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
+	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=2 lorax_server/cli.py serve mistralai/Mistral-7B-Instruct-v0.1 --sharded
+	SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve mistralai/Mistral-7B-v0.1 --sharded
 	# SAFETENSORS_FAST_GPU=1 python -m torch.distributed.run --nproc_per_node=1 lorax_server/cli.py serve flozi00/Mistral-7B-german-assistant-v5-4bit-autogptq --quantize gptq
 
 export-requirements:

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -17,18 +17,8 @@ except ImportError:
 
 from accelerate import init_empty_weights
 
-<<<<<<< Updated upstream
-=======
-try:
-    from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, lora_a_sgmv_cutlass, lora_b_sgmv_cutlass
-    HAS_SGMV = True
-except ImportError:
-    warnings.warn("Could not import SGMV kernel from Punica, falling back to loop.")
-    HAS_SGMV = False
-
->>>>>>> Stashed changes
 from lorax_server.utils.gptq.quant_linear import QuantLinear
-from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, has_sgmv, orient_for_rank
+from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, lora_a_sgmv_cutlass, lora_b_sgmv_cutlass, has_sgmv, orient_for_rank
 
 HAS_EXLLAMA = True
 if os.getenv("DISABLE_EXLLAMA") == "True":

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -362,7 +362,7 @@ class TensorParallelAdapterLinear(nn.Module):
                         rank_segments.segment_starts,
                         rank_segments.segment_ends,
                         self.layer_id,
-                        r,
+                        r // self.process_group.size(),
                     )
 
                     if self.process_group.size() > 1:

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -349,7 +349,7 @@ class TensorParallelAdapterLinear(nn.Module):
         end_idx: int,
     ) -> torch.Tensor:
         data = adapter_data.data.get(layer_type)
-        if has_sgmv() and data is not None:
+        if has_sgmv() and data is not None and data.can_vectorize(self.process_group):
             proj = torch.zeros_like(result[:, start_idx:end_idx])
 
             for r, rank_segments in data.rank_data.items():

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -17,6 +17,16 @@ except ImportError:
 
 from accelerate import init_empty_weights
 
+<<<<<<< Updated upstream
+=======
+try:
+    from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, lora_a_sgmv_cutlass, lora_b_sgmv_cutlass
+    HAS_SGMV = True
+except ImportError:
+    warnings.warn("Could not import SGMV kernel from Punica, falling back to loop.")
+    HAS_SGMV = False
+
+>>>>>>> Stashed changes
 from lorax_server.utils.gptq.quant_linear import QuantLinear
 from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, has_sgmv, orient_for_rank
 
@@ -349,26 +359,33 @@ class TensorParallelAdapterLinear(nn.Module):
         end_idx: int,
     ) -> torch.Tensor:
         data = adapter_data.data.get(layer_type)
-        if (
-            has_sgmv() and
-            self.process_group.size() == 1 and
-            data is not None
-        ):
+        if has_sgmv() and data is not None:
             proj = torch.zeros_like(result[:, start_idx:end_idx])
 
             for r, rank_segments in data.rank_data.items():
                 lora_a_ptr = rank_segments.lora_a_ptr
                 lora_b_ptr = rank_segments.lora_b_ptr
                 if lora_a_ptr is not None and lora_b_ptr is not None:
-                    add_lora_sgmv_cutlass(
-                        proj,
+                    v, tmp = lora_a_sgmv_cutlass(
                         input,
                         lora_a_ptr,
-                        lora_b_ptr,
                         rank_segments.segment_starts,
                         rank_segments.segment_ends,
                         self.layer_id,
                         r,
+                    )
+
+                    if self.process_group.size() > 1:
+                        v = self.collect_lora_a(v)
+
+                    lora_b_sgmv_cutlass(
+                        proj,
+                        v,
+                        tmp,
+                        lora_b_ptr,
+                        rank_segments.segment_starts,
+                        rank_segments.segment_ends,
+                        self.layer_id,
                     )
             
             result[:, start_idx:end_idx] += proj

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -6,7 +6,7 @@ import torch
 from peft import LoraConfig
 from torch.distributed import ProcessGroup
 
-from lorax_server.utils.sgmv import orient_for_rank
+from lorax_server.utils.sgmv import MIN_SGMV_RANK, orient_for_rank
 from lorax_server.utils.weights import shard_on_dim
 
 
@@ -47,6 +47,12 @@ class AdapterWeightData:
     
     def has_adapter(self, adapter_index: int) -> bool:
         return adapter_index in self.adapter_index_configs
+    
+    def can_vectorize(self, pg: ProcessGroup) -> bool:
+        return all(
+            rank_data.rank // pg.size() >= MIN_SGMV_RANK
+            for rank_data in self.rank_data.values()
+        )
     
 
 @dataclass

--- a/server/lorax_server/utils/sgmv.py
+++ b/server/lorax_server/utils/sgmv.py
@@ -13,6 +13,7 @@ except ImportError:
     HAS_SGMV = False
 
 
+MIN_SGMV_RANK = 8
 MIN_RANK_CUSTOM = 16
 MAX_RANK_CUSTOM = 128
 

--- a/server/lorax_server/utils/sgmv.py
+++ b/server/lorax_server/utils/sgmv.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Tuple
 
 import torch
-from torch.distributed import ProcessGroup
 
 try:
     import punica_kernels as _kernels
@@ -91,11 +90,9 @@ def lora_a_sgmv_cutlass(
     s_end: torch.IntTensor,
     layer_idx: int,
     lora_rank: int,
-    process_group: ProcessGroup,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    sharded_lora_rank = lora_rank // process_group.size()
-    v = torch.zeros((x.size(0), sharded_lora_rank), dtype=x.dtype, device=x.device)
-    if MIN_RANK_CUSTOM <= sharded_lora_rank <= MAX_RANK_CUSTOM:
+    v = torch.zeros((x.size(0), lora_rank), dtype=x.dtype, device=x.device)
+    if MIN_RANK_CUSTOM <= lora_rank <= MAX_RANK_CUSTOM:
         tmp1 = torch.empty((8 * 1024 * 1024,), dtype=torch.uint8, device=x.device)
         tmp2_size = _kernels.sgmv_cutlass_tmp_size(wa_ptr.size(0))
         tmp = torch.empty((tmp2_size,), dtype=torch.uint8, device=x.device)

--- a/server/tests/utils/test_sgmv.py
+++ b/server/tests/utils/test_sgmv.py
@@ -1,0 +1,78 @@
+import pytest
+import torch
+
+from lorax_server.utils.sgmv import add_lora_sgmv_cutlass, has_sgmv, orient_for_rank
+
+
+def lora_ref_impl(
+    y: torch.Tensor,
+    x: torch.Tensor,
+    wa: torch.Tensor,
+    wb: torch.Tensor,
+    s_start: torch.IntTensor,
+    s_end: torch.IntTensor,
+    layer_idx: int,
+):
+    for i in range(len(wa)):
+        xi = x[s_start[i]:s_end[i]]
+        wai = wa[i][layer_idx, :, :]
+        wbi = wb[i][layer_idx, :, :]
+        yi = y[s_start[i]:s_end[i]]
+        tmp = (xi @ wai)
+        y[s_start[i]:s_end[i]] = (yi + tmp @ wbi)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not has_sgmv(), reason="SGMV not available")
+@pytest.mark.parametrize("lora_rank", [4, 8, 16, 32, 64, 128])
+def test_add_lora_sgmv_cutlass(lora_rank: int):
+    B = 3
+    H = 1024
+    r = lora_rank
+    nlayers = 2
+
+    device = torch.device("cuda:0")
+    
+    y = torch.zeros((B, H), dtype=torch.float16, device=device)
+    x = torch.randn((B, H), dtype=torch.float16, device=device)
+    wa = torch.randn(nlayers, H, r, dtype=torch.float16, device=device)
+    wb = torch.randn(nlayers, r, H, dtype=torch.float16, device=device)
+
+    wa_sgmv = orient_for_rank(wa, lora_rank)
+    wa_ptr = torch.tensor([wa_sgmv.data_ptr(), wa_sgmv.data_ptr()], dtype=torch.int64, device=device)
+    wb_ptr = torch.tensor([wb.data_ptr(), wb.data_ptr()], dtype=torch.int64, device=device)
+
+    s_start = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    s_end = torch.tensor([1, 3], dtype=torch.int32, device=device)
+
+    layer_idx = 0
+
+    y_ref = y.clone()
+    lora_ref_impl(y_ref, x, [wa, wa], [wb, wb], s_start, s_end, layer_idx)
+    # print(y_ref)
+
+    lora_a = wa[0, :, :]
+    lora_b = wb[0, :, :]
+    mask = torch.tensor([1.0, 0.0, 1.0], dtype=torch.float16, device=device)
+    # out = torch.matmul(torch.matmul(x, lora_a), lora_b)
+    out = ((x @ lora_a) @ lora_b) * mask.view(-1, 1)
+    # print(x @ lora_a)
+    # print(out)
+
+    # assert torch.allclose(y_ref, out)
+
+    y_ours = torch.zeros((B, H), dtype=torch.float16, device=device)
+    add_lora_sgmv_cutlass(
+        y_ours,
+        x,
+        wa_ptr,
+        wb_ptr,
+        s_start,
+        s_end,
+        layer_idx,
+        r,
+    )
+    # print(y_ours)
+
+    # assert torch.allclose(y_ref, y_ours)
+    assert torch.allclose(out, y_ours)


### PR DESCRIPTION
This PR combines tensor parallelism with the SGMV vectorized CUDA kernel code path. In effect, this also addresses most of the pain points identified #6, as we only require one collective op per rank instead of one per adapter. The one caveat here is that the SGMV kernel doesn't work with ranks < 8, and since tensor parallelism reduces the effective rank of the tensor, this means we need to fallback on the loop implementation any time `rank / world_size < 8`. We'll try to address this in future iterations by extending the SGMV kernel to support ranks < 8 (#78).