### PR TITLE
fix: Assign dtype of lora to base model dtype

### DIFF
--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -771,8 +771,8 @@ class FlashCausalLM(Model):
                 # There is no LoRA weight for this layer type in the adapter
                 return
             
-            lora_a = module_map[weight_name]["lora_A"].to(base_device, base_weight.dtype)
-            lora_b = module_map[weight_name]["lora_B"].to(base_device, base_weight.dtype)
+            lora_a = module_map[weight_name]["lora_A"].to(base_device, self.dtype)
+            lora_b = module_map[weight_name]["lora_B"].to(base_device, self.dtype)
             scale = adapter_config.lora_alpha / adapter_config.r
 
             # Merge scaling factor into lora_b due to associativity of matrix multiplication:


### PR DESCRIPTION
Fixes #74.

When the model is quantized, the dtype of the weights (compressed) is typically uint or similar. This means if we cast the lora weights to the weight of the parent layer, it will corrupt them, rendering the output garbage. Instead, we should assign the dtype of the base model (float16 or bloat16) to the lora weights, which is consistent with how inference in QLoRA is done outside LoRAX (quantized weights + unquantized lora).