### PR TITLE
Update values.yaml tag to always use the latest image

### DIFF
--- a/charts/lorax/values.yaml
+++ b/charts/lorax/values.yaml
@@ -4,7 +4,7 @@ deployment:
 
   image:
     repository: "ghcr.io/predibase/lorax"
-    tag: "f76119a"
+    tag: "f1b9778"
 
   args:
     modelId: "mistralai/Mistral-7B-Instruct-v0.1"

--- a/charts/lorax/values.yaml
+++ b/charts/lorax/values.yaml
@@ -4,7 +4,7 @@ deployment:
 
   image:
     repository: "ghcr.io/predibase/lorax"
-    tag: "f1b9778"
+    tag: "latest"
 
   args:
     modelId: "mistralai/Mistral-7B-Instruct-v0.1"


### PR DESCRIPTION
This PR updates the image tag in `charts/lorax/values.yaml` to always ensure that deployments are created using the latest image that's been released. 