### PR TITLE
fix static adapter merge

### DIFF
--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -126,6 +126,12 @@ def merge_adapter_weights(
         lora_B = adapter_weights[adapter_weight_names["lora_B"]]
         delta_weight = compute_delta_weight(
             lora_A, lora_B, adapter_config.fan_in_fan_out, adapter_config.lora_alpha, adapter_config.r)
+        
+        # transpose delta weight if necessary
+        # TODO(geoffrey): I believe this is required when using Conv1D layers (gpt2).
+        # We can likely take this out once we've switched to using Linear layers.
+        if delta_weight.T.shape == model_weights[weight_name].shape:
+            delta_weight = delta_weight.T
         merged_weights[weight_name] = model_weights[weight_name] + delta_weight
     return merged_weights, processed_adapter_weight_names
 


### PR DESCRIPTION
fixes loading LoRA statically into GPT-2. Likely need the transpose because PEFT treats conv1d layers as transposed linear layers.