### PR TITLE
LoRAX-compatible GPT-2

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_gpt2_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_gpt2_modeling.py
@@ -205,11 +205,13 @@ class GPT2MLP(nn.Module):
             bias=True,
             fan_in_fan_out=True,
         )
+        # https://huggingface.co/docs/transformers/model_doc/gpt2#transformers.GPT2Config.n_inner
+        n_inner = config.n_inner if config.n_inner is not None else config.n_embd * 4
         self.c_fc = TensorParallelMultiAdapterLinear.load(
             c_fc, 
             layer_id, 
             [MLP_C_FC], 
-            sizes=[config.n_embd],
+            sizes=[n_inner],
             process_group=weights.process_group
         )
 

--- a/server/lorax_server/models/flash_gpt2.py
+++ b/server/lorax_server/models/flash_gpt2.py
@@ -6,12 +6,18 @@ from loguru import logger
 from opentelemetry import trace
 from transformers import AutoTokenizer, GPT2Model
 from tqdm import tqdm
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 from lorax_server.models import FlashCausalLM
 from lorax_server.models.custom_modeling.flash_gpt2_modeling import (
     FlashGPT2ForCausalLM,
     GPT2Config,
+    ADAPTER_LAYERS,
+    ATTN_C_ATTN,
+    ATTN_C_PROJ,
+    MLP_C_FC,
+    MLP_C_PROJ,
+    LM_HEAD,
 )
 from lorax_server.utils import (
     compute_delta_weight,
@@ -95,19 +101,37 @@ class FlashGPT2(FlashCausalLM):
         super(FlashGPT2, self).__init__(
             model=model,
             tokenizer=tokenizer,
-            num_layers=len(model.model.layers),
-            num_kv_heads=model.model.num_key_value_heads,
-            head_size=model.model.head_size,
+            num_layers=len(model.transformer.h),
+            num_kv_heads=model.transformer.num_key_value_heads,
+            head_size=model.transformer.head_size,
             dtype=dtype,
             device=device,
             rank=rank,
             world_size=world_size,
         )
-    
-    def get_adaptable_weights(self):
-        # TODO: enable dynamic adapter loading in LoRAX
-        return {}
-    
+
     @property
     def supports_adapter_loading(self) -> bool:
         return True
+    
+    def adapter_target_to_layer(self) -> Dict[str, Tuple[str, torch.Tensor]]:
+        layer_weights = {}
+
+        prefix = "transformer.h"
+        for i, layer in enumerate(self.model.transformer.h):
+            layer_weights[(i, ATTN_C_ATTN)] = (f"{prefix}.{i}.{ATTN_C_ATTN}", layer.attn.c_attn)
+            layer_weights[(i, ATTN_C_PROJ)] = (f"{prefix}.{i}.{ATTN_C_PROJ}", layer.attn.c_proj)
+
+            layer_weights[(i, MLP_C_FC)] = (f"{prefix}.{i}.{MLP_C_FC}", layer.mlp.c_fc)
+            layer_weights[(i, MLP_C_PROJ)] = (f"{prefix}.{i}.{MLP_C_PROJ}", layer.mlp.c_proj)
+
+        # TODO: make Embedding layers adapter-compatible
+        # layer_weights[(0, LM_HEAD)] = ("transformer.wte", self.model.transformer.wte)
+        return layer_weights
+    
+    @property
+    def adapter_layers(self) -> List[str]:
+        return ADAPTER_LAYERS
+    
+    def get_num_layers_for_type(self, layer_type: str) -> int:
+        return 1 if layer_type == LM_HEAD else len(self.model.transformer.h)

--- a/server/lorax_server/models/flash_gpt2.py
+++ b/server/lorax_server/models/flash_gpt2.py
@@ -12,7 +12,6 @@ from lorax_server.models import FlashCausalLM
 from lorax_server.models.custom_modeling.flash_gpt2_modeling import (
     FlashGPT2ForCausalLM,
     GPT2Config,
-    ADAPTER_LAYERS,
     ATTN_C_ATTN,
     ATTN_C_PROJ,
     MLP_C_FC,
@@ -31,6 +30,9 @@ from lorax_server.utils import (
 from lorax_server.utils.adapter import BASE_MODEL_ADAPTER_ID
 
 tracer = trace.get_tracer(__name__)
+
+ADAPTER_LAYERS = [ATTN_C_ATTN, ATTN_C_PROJ, MLP_C_FC, MLP_C_PROJ]
+ROW_PARALLEL = {ATTN_C_PROJ, MLP_C_PROJ}
 
 
 class FlashGPT2(FlashCausalLM):
@@ -135,3 +137,6 @@ class FlashGPT2(FlashCausalLM):
     
     def get_num_layers_for_type(self, layer_type: str) -> int:
         return 1 if layer_type == LM_HEAD else len(self.model.transformer.h)
+    
+    def is_row_parallel(self, layer_type: str) -> bool:
+        return layer_type in ROW_PARALLEL

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -130,7 +130,8 @@ def merge_adapter_weights(
         # transpose delta weight if necessary
         # TODO(geoffrey): I believe this is required when using Conv1D layers (gpt2).
         # We can likely take this out once we've switched to using Linear layers.
-        if delta_weight.T.shape == model_weights[weight_name].shape:
+        if (delta_weight.shape != model_weights[weight_name].shape and 
+            delta_weight.T.shape == model_weights[weight_name].shape):
             delta_weight = delta_weight.T
         merged_weights[weight_name] = model_weights[weight_name] + delta_weight
     return merged_weights, processed_adapter_weight_names

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -126,6 +126,12 @@ def merge_adapter_weights(
         lora_B = adapter_weights[adapter_weight_names["lora_B"]]
         delta_weight = compute_delta_weight(
             lora_A, lora_B, adapter_config.fan_in_fan_out, adapter_config.lora_alpha, adapter_config.r)
+        
+        # transpose delta weight if necessary
+        # TODO(geoffrey): I believe this is required when using Conv1D layers (gpt2).
+        # We can likely take this out once we've switched to using Linear layers.
+        if delta_weight.T.shape == model_weights[weight_name].shape:
+            delta_weight = delta_weight.T
         merged_weights[weight_name] = model_weights[weight_name] + delta_weight
     return merged_weights, processed_adapter_weight_names
 

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -335,19 +335,20 @@ class TensorParallelHead(SuperLayer):
 
 class TensorParallelColumnLinear(SuperLayer):
     @classmethod
-    def load_qkv(cls, config, prefix: str, weights, bias: bool):
+    def load_qkv(cls, config, prefix: str, weights, bias: bool, fan_in_fan_out=False):
         """Specific method when the QKV was joined after the fact"""
         weight = weights.get_weights_col_packed_qkv(prefix, quantize=config.quantize)
         if bias:
             raise NotImplementedError("packed_qkv only implemented for baichuan")
         else:
             bias = None
-        linear = get_linear(weight, bias, config.quantize)
+        linear = get_linear(weight, bias, config.quantize, fan_in_fan_out=fan_in_fan_out)
         return cls(linear)
 
     @classmethod
-    def load(cls, config, prefix: str, weights, bias: bool):
-        return cls.load_multi(config, [prefix], weights, bias, dim=0)
+    def load(cls, config, prefix: str, weights, bias: bool, fan_in_fan_out: bool = False):
+        return cls.load_multi(
+            config, [prefix], weights, bias, dim=0, fan_in_fan_out=fan_in_fan_out)
 
     @classmethod
     def load_multi(

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -208,7 +208,12 @@ class Linear4bit(nn.Module):
 
         return out
 
-def get_linear(weight, bias, quantize):
+def get_linear(weight, bias, quantize, fan_in_fan_out=False):
+    # https://huggingface.co/docs/peft/package_reference/tuners#peft.LoraConfig.fan_in_fan_out
+    # Set to True if replacing a Conv1D layer with a Linear layer
+    if fan_in_fan_out:
+        weight = weight.T
+
     if quantize is None:
         linear = FastLinear(weight, bias)
     elif quantize == "bitsandbytes":
@@ -345,7 +350,15 @@ class TensorParallelColumnLinear(SuperLayer):
         return cls.load_multi(config, [prefix], weights, bias, dim=0)
 
     @classmethod
-    def load_multi(cls, config, prefixes: List[str], weights, bias: bool, dim: int):
+    def load_multi(
+        cls, 
+        config, 
+        prefixes: List[str], 
+        weights, 
+        bias: bool, 
+        dim: int, 
+        fan_in_fan_out=False
+    ):
         weight = weights.get_multi_weights_col(
             prefixes, quantize=config.quantize, dim=dim
         )
@@ -355,7 +368,7 @@ class TensorParallelColumnLinear(SuperLayer):
             bias = torch.cat(b, dim=dim)
         else:
             bias = None
-        linear = get_linear(weight, bias, config.quantize)
+        linear = get_linear(weight, bias, config.quantize, fan_in_fan_out=fan_in_fan_out)
         return cls(linear)
     
 
@@ -514,7 +527,14 @@ class TensorParallelRowLinear(SuperLayer):
         self.process_group = process_group
 
     @classmethod
-    def load(cls, config, prefix: str, weights, bias: bool):
+    def load(
+        cls, 
+        config, 
+        prefix: str, 
+        weights, 
+        bias: bool, 
+        fan_in_fan_out: bool = False
+    ):
         weight = weights.get_multi_weights_row(prefix, quantize=config.quantize)
 
         if bias and weights.process_group.rank() == 0:
@@ -523,7 +543,7 @@ class TensorParallelRowLinear(SuperLayer):
         else:
             bias = None
         return cls(
-            get_linear(weight, bias, config.quantize),
+            get_linear(weight, bias, config.quantize, fan_in_fan_out=fan_in_fan_out),
             process_group=weights.process_group,
         )
 


### PR DESCRIPTION
Adds LoRAX for GPT-2 with support for the following target modules:
- `transformer.h.{layer}.attn.c_attn`
- `transformer.h.{layer}.attn.c_proj`
- `transformer.h.{layer}.mlp.c_fc`
- `transformer.h.{layer}.mlp.c_proj`