### PR TITLE
Generalized layer types and row parallel split logic

### DIFF
--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -711,6 +711,9 @@ class FlashCausalLM(Model):
     
     def get_num_layers_for_type(self, layer_type: str) -> int:
         return 0
+    
+    def is_row_parallel(self, layer_type: str) -> bool:
+        return False
 
     def load_adapter(self, adapter_id, adapter_source, adapter_index):
         """Physically loads the adapter weights into the model.
@@ -791,7 +794,9 @@ class FlashCausalLM(Model):
             lora_a_list[layer_id] = lora_a.transpose(0, 1)
             lora_b_list[layer_id] = lora_b.transpose(0, 1) * scale
 
-        q_lora_merged = MergedLoraWeights(lora_a_list, lora_b_list, adapter_config, layer_type, self.process_group)
+        q_lora_merged = MergedLoraWeights(
+            lora_a_list, lora_b_list, adapter_config, layer_type, self.process_group, self.is_row_parallel(layer_type),
+        )
         q_lora_weights = self.batched_lora_weights[layer_type]
         q_lora_weights.add_adapter(adapter_index, q_lora_merged)
     

--- a/server/lorax_server/models/flash_llama.py
+++ b/server/lorax_server/models/flash_llama.py
@@ -24,7 +24,8 @@ from lorax_server.utils.lora import DOWN_PROJ, GATE_PROJ, K_PROJ, LM_HEAD, O_PRO
 tracer = trace.get_tracer(__name__)
 
 
-ADAPTER_LAYERS = [Q_PROJ, K_PROJ, V_PROJ, O_PROJ, GATE_PROJ, UP_PROJ, DOWN_PROJ]
+ADAPTER_LAYERS = [Q_PROJ, K_PROJ, V_PROJ, O_PROJ, GATE_PROJ, UP_PROJ, DOWN_PROJ, LM_HEAD]
+ROW_PARALLEL = {O_PROJ, DOWN_PROJ, LM_HEAD}
 
 
 class FlashLlama(FlashCausalLM):
@@ -131,3 +132,6 @@ class FlashLlama(FlashCausalLM):
     
     def get_num_layers_for_type(self, layer_type: str) -> int:
         return 1 if layer_type == LM_HEAD else len(self.model.model.layers)
+    
+    def is_row_parallel(self, layer_type: str) -> bool:
+        return layer_type in ROW_PARALLEL

--- a/server/lorax_server/models/flash_mistral.py
+++ b/server/lorax_server/models/flash_mistral.py
@@ -39,7 +39,8 @@ tracer = trace.get_tracer(__name__)
 SLIDING_WINDOW: Optional[int] = None
 SLIDING_WINDOW_BLOCKS: Optional[int] = None
 
-ADAPTER_LAYERS = [Q_PROJ, K_PROJ, V_PROJ, O_PROJ, GATE_PROJ, UP_PROJ, DOWN_PROJ]
+ADAPTER_LAYERS = [Q_PROJ, K_PROJ, V_PROJ, O_PROJ, GATE_PROJ, UP_PROJ, DOWN_PROJ, LM_HEAD]
+ROW_PARALLEL = {O_PROJ, DOWN_PROJ, LM_HEAD}
 
 
 # Adds windowing logic to FlashCausalLMBatch
@@ -434,3 +435,6 @@ class FlashMistral(FlashCausalLM):
     
     def get_num_layers_for_type(self, layer_type: str) -> int:
         return 1 if layer_type == LM_HEAD else len(self.model.model.layers)
+    
+    def is_row_parallel(self, layer_type: str) -> bool:
+        return layer_type in ROW_PARALLEL

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -22,9 +22,6 @@ DOWN_PROJ = "down_proj"
 
 LM_HEAD = "lm_head"
 
-# TODO(travis): push this down into the model
-ROW_PARALLEL = {O_PROJ, DOWN_PROJ, LM_HEAD, "c_proj"}
-
 EMPTY_TENSOR = torch.tensor([])
 
 
@@ -87,9 +84,10 @@ class MergedLoraWeights:
         adapter_config: LoraConfig,
         layer_type: str,
         process_group: ProcessGroup,
+        is_row_parallel: bool,
     ):
         # [num_layers, hidden_size, r]
-        split_dim = 0 if layer_type in ROW_PARALLEL else 1
+        split_dim = 0 if is_row_parallel else 1
         weights_a = [
             orient_for_rank(shard_on_dim(w, dim=split_dim, process_group=process_group), adapter_config.r)
             for w in weights_a


### PR DESCRIPTION
Fixes a key conflict where `c_proj` was used for different layers in different modules.