### PR TITLE
Increase default client timeout to 60s

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -40,7 +40,7 @@ class Client:
         base_url: str,
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
-        timeout: int = 10,
+        timeout: int = 60,
     ):
         """
         Args:
@@ -298,7 +298,7 @@ class AsyncClient:
         base_url: str,
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
-        timeout: int = 10,
+        timeout: int = 60,
     ):
         """
         Args:


### PR DESCRIPTION
A number of users have run into connection failures for long sequences due to the 10s timeout (#115). This PR increases the timeout to 60s.