### PR TITLE
fix: Set Mistral sliding window to max position embeddings when None

### DIFF
--- a/server/lorax_server/models/flash_mistral.py
+++ b/server/lorax_server/models/flash_mistral.py
@@ -334,6 +334,9 @@ class FlashMistral(FlashCausalLM):
         )
         config.quantize = quantize
 
+        if config.sliding_window is None:
+            config.sliding_window = config.max_position_embeddings
+
         # Set context windows
         SLIDING_WINDOW = config.sliding_window
         SLIDING_WINDOW_BLOCKS = math.ceil(config.sliding_window / BLOCK_SIZE)

--- a/server/lorax_server/models/flash_mixtral.py
+++ b/server/lorax_server/models/flash_mixtral.py
@@ -341,6 +341,9 @@ class FlashMixtral(FlashCausalLM):
         )
         config.quantize = quantize
 
+        if config.sliding_window is None:
+            config.sliding_window = config.max_position_embeddings
+
         # Set context windows
         SLIDING_WINDOW = config.sliding_window
         SLIDING_WINDOW_BLOCKS = math.ceil(config.sliding_window / BLOCK_SIZE)


### PR DESCRIPTION
Fixes #127.

The latest v0.2 Mistral model has a `None` sliding window in the config. Allowing `sliding_window` to be `None` appears to cause the model to output nonsense if we attempt to allow it. Empirically, setting it to the max position embeddings gets it to generate results that seem reasonable.