### PR TITLE
Make transpose contiguous for fan-in-fan-out

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_gpt2_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_gpt2_modeling.py
@@ -363,6 +363,7 @@ class FlashGPT2ForCausalLM(FlashGPT2PreTrainedModel):
     def __init__(self, config, weights):
         super().__init__(config)
         self.transformer = FlashGPT2Model(config, weights)
+        self.wte_t = self.transformer.wte.weight.T.contiguous()
 
     def forward(
         self,
@@ -393,6 +394,6 @@ class FlashGPT2ForCausalLM(FlashGPT2PreTrainedModel):
 
         # lm_head reuses the weights of the embedding layer
         # https://github.com/huggingface/transformers/issues/6291
-        logits = hidden_states @ self.transformer.wte.weight.T
+        logits = hidden_states @ self.wte_t
         logits = logits[:, :self.transformer.config.vocab_size]
         return logits

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -218,7 +218,7 @@ def get_linear(weight, bias, quantize, fan_in_fan_out=False):
     # https://huggingface.co/docs/peft/package_reference/tuners#peft.LoraConfig.fan_in_fan_out
     # Set to True if replacing a Conv1D layer with a Linear layer
     if fan_in_fan_out:
-        weight = weight.T
+        weight = weight.T.contiguous()
 
     if quantize is None:
         linear = FastLinear(weight, bias)


### PR DESCRIPTION
Making the transpose contiguous improves batching effect and creates an observed reduction in latency with gpt-2 in testing on A100 from 113ms / 10 tokens to 108ms / 10 tokens.