### PR TITLE
remove CACHE_MANAGER in flash_causal_lm.py

### DIFF
--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -913,8 +913,6 @@ class FlashCausalLM(Model):
         )
 
     def forward(self, batch: FlashCausalLMBatch, adapter_data: AdapterBatchData) -> Tuple[torch.Tensor, torch.Tensor]:
-        global CACHE_MANAGER
-
         # Model Forward
         return self.model.forward(
             input_ids=batch.input_ids,


### PR DESCRIPTION
global var CACHE_MANAGER should no longer be needed here, fyi.