### PR TITLE
Fixed Phi for new HF format

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_phi_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_phi_modeling.py
@@ -32,28 +32,29 @@ from lorax_server.utils.layers import (
 from lorax_server.utils.lora import LM_HEAD, AdapterBatchData
 
 
-ATTN_WQKV = "mixer.Wqkv"
-ATTN_OUT_PROJ = "mixer.out_proj"
+ATTN_Q_PROJ = "self_attn.q_proj"
+ATTN_K_PROJ = "self_attn.k_proj"
+ATTN_V_PROJ = "self_attn.v_proj"
+ATTN_DENSE = "self_attn.dense"
 MLP_FC1 = "mlp.fc1"
 MLP_FC2 = "mlp.fc2"
         
 
 def load_attention(config, prefix, weights, layer_id, head_dim, n_head, n_head_kv):
-    op_size = head_dim * (n_head + 2 * n_head_kv)
     base_layer = load_attention_multi(config, prefix, weights, head_dim, n_head, n_head_kv)
     return TensorParallelMultiAdapterLinear.load(
-        base_layer, layer_id, [ATTN_WQKV], sizes=[op_size], process_group=weights.process_group
+        base_layer, layer_id, [ATTN_Q_PROJ, ATTN_K_PROJ, ATTN_V_PROJ], sizes=[
+            head_dim * n_head,
+            head_dim * n_head_kv,
+            head_dim * n_head_kv,
+        ], process_group=weights.process_group
     )
 
 
 def load_attention_multi(config, prefix, weights, head_dim, n_head, n_head_kv):
     return TensorParallelColumnLinear.load_multi(
         config,
-        prefixes=[
-            (f"{prefix}.Wqkv", (0, head_dim * n_head)),
-            (f"{prefix}.Wqkv", (head_dim * n_head, head_dim * n_head_kv)),
-            (f"{prefix}.Wqkv", ((head_dim * n_head) + (head_dim * n_head_kv), head_dim * n_head_kv)),
-        ],
+        prefixes=[f"{prefix}.q_proj", f"{prefix}.k_proj", f"{prefix}.v_proj"],
         dim=0,
         weights=weights,
         bias=True,
@@ -69,17 +70,18 @@ class FlashPhiAttention(torch.nn.Module):
         layer_id: int,
     ):
         super().__init__()
-        self.num_heads = config.n_head
-        self.hidden_size = config.n_embd
+        self.num_heads = config.num_attention_heads
+        self.hidden_size = config.hidden_size
         self.head_size = self.hidden_size // self.num_heads
         self.process_group = weights.process_group
 
         rope_theta = 10000
         config.max_position_embeddings = getattr(config, "n_positions", 2048)
 
+        rotary_dim = int(config.partial_rotary_factor * (config.hidden_size // config.num_attention_heads))
         self.rotary_emb = PositionRotaryEmbedding.static(
             config=config,
-            dim=config.rotary_dim,
+            dim=rotary_dim,
             base=rope_theta,
             device=weights.device,
             dtype=weights.dtype,
@@ -94,13 +96,13 @@ class FlashPhiAttention(torch.nn.Module):
             )
         self.num_key_value_heads = getattr(config, "n_head_kv", None) or self.num_heads
 
-        self.Wqkv = load_attention(config, prefix, weights, layer_id, self.head_size, self.num_heads, self.num_key_value_heads)
-        self.out_proj = TensorParallelAdapterRowLinear.load(TensorParallelRowLinear.load(
+        self.qkv_proj = load_attention(config, prefix, weights, layer_id, self.head_size, self.num_heads, self.num_key_value_heads)
+        self.dense = TensorParallelAdapterRowLinear.load(TensorParallelRowLinear.load(
             config,
-            prefix=f"{prefix}.out_proj",
+            prefix=f"{prefix}.dense",
             weights=weights,
             bias=True,
-        ), layer_id, ATTN_OUT_PROJ, process_group=weights.process_group)
+        ), layer_id, ATTN_DENSE, process_group=weights.process_group)
 
         # After initializing layers, scale num heads by num shards for use in forward() to split outputs
         self.num_heads = self.num_heads // weights.process_group.size()
@@ -125,7 +127,7 @@ class FlashPhiAttention(torch.nn.Module):
         max_s,
         adapter_data,
     ):
-        qkv = self.Wqkv(hidden_states, adapter_data)
+        qkv = self.qkv_proj(hidden_states, adapter_data)
         query, kv = qkv.split(
             [
                 self.head_size * self.num_heads,
@@ -173,13 +175,13 @@ class FlashPhiAttention(torch.nn.Module):
                 max_s,
             )
 
-        return self.out_proj(attn_output.view(-1, self.num_heads * self.head_size), adapter_data)
+        return self.dense(attn_output.view(-1, self.num_heads * self.head_size), adapter_data)
 
 
 class PhiMLP(nn.Module):
     def __init__(self, prefix, config, weights, layer_id):
         super().__init__()
-        act = config.activation_function
+        act = config.hidden_act
         self.act = (
             ACT2FN[act]
             if "gelu" not in act
@@ -220,13 +222,13 @@ class PhiMLP(nn.Module):
 class FlashPhiLayer(nn.Module):
     def __init__(self, layer_id, config, weights):
         super().__init__()
-        prefix = f"transformer.h.{layer_id}"
+        prefix = f"model.layers.{layer_id}"
         
-        self.ln = FastLayerNorm.load(
-            prefix=f"{prefix}.ln", weights=weights, eps=config.layer_norm_epsilon
+        self.input_layernorm = FastLayerNorm.load(
+            prefix=f"{prefix}.input_layernorm", weights=weights, eps=config.layer_norm_eps
         )
-        self.mixer = FlashPhiAttention(
-            prefix=f"{prefix}.mixer", config=config, weights=weights, layer_id=layer_id,
+        self.self_attn = FlashPhiAttention(
+            prefix=f"{prefix}.self_attn", config=config, weights=weights, layer_id=layer_id,
         )
         self.mlp = PhiMLP(prefix=f"{prefix}.mlp", config=config, weights=weights, layer_id=layer_id)
         self.process_group = weights.process_group
@@ -245,9 +247,9 @@ class FlashPhiLayer(nn.Module):
         max_s,
         adapter_data,
     ):
-        normed_hidden_states, _ = self.ln(hidden_states, residual=None)
+        normed_hidden_states, _ = self.input_layernorm(hidden_states, residual=None)
 
-        attn_output = self.mixer(
+        attn_output = self.self_attn(
             normed_hidden_states,
             cos,
             sin,
@@ -276,25 +278,28 @@ class FlashPhiModel(torch.nn.Module):
         process_group = weights.process_group
         self.tp_rank = process_group.rank()
         self.tp_world_size = process_group.size()
-        self.embd = TensorParallelEmbedding(
-            prefix="transformer.embd.wte", weights=weights
+        self.embed_tokens = TensorParallelEmbedding(
+            prefix="model.embed_tokens", weights=weights
         )
-        self.h = nn.ModuleList(
+        self.layers = nn.ModuleList(
             [
                 FlashPhiLayer(
                     layer_id,
                     config,
                     weights,
                 )
-                for layer_id in range(config.n_layer)
+                for layer_id in range(config.num_hidden_layers)
             ]
+        )
+        self.final_layernorm = FastLayerNorm.load(
+            prefix="model.final_layernorm", weights=weights, eps=config.layer_norm_eps
         )
 
         self.gradient_checkpointing = False
 
-        self.head_size = self.h[0].mixer.head_size
-        self.num_heads = self.h[0].mixer.num_heads
-        self.num_key_value_heads = self.h[0].mixer.num_key_value_heads
+        self.head_size = self.layers[0].self_attn.head_size
+        self.num_heads = self.layers[0].self_attn.num_heads
+        self.num_key_value_heads = self.layers[0].self_attn.num_key_value_heads
 
     def forward(
         self,
@@ -308,16 +313,16 @@ class FlashPhiModel(torch.nn.Module):
         max_s: int,
         adapter_data: AdapterBatchData,
     ) -> torch.Tensor:
-        hidden_states = self.embd(input_ids)
+        hidden_states = self.embed_tokens(input_ids)
 
         # Get rotary cos and sin for this forward
         # Avoid to index in each layer
-        cos, sin = self.h[0].mixer.rotary_emb.get_cos_sin(
+        cos, sin = self.layers[0].self_attn.rotary_emb.get_cos_sin(
             position_ids, max_s, hidden_states.dtype
         )
 
         residual = None
-        for i, layer in enumerate(self.h):
+        for i, layer in enumerate(self.layers):
             hidden_states, residual = layer(
                 hidden_states,
                 residual,
@@ -331,27 +336,8 @@ class FlashPhiModel(torch.nn.Module):
                 max_s,
                 adapter_data,
             )
-
-        return hidden_states
-
-
-class PhiCausalLMHead(torch.nn.Module):
-    def __init__(self, config, weights):
-        super().__init__()
-
-        prefix = "lm_head"
-        self.ln = FastLayerNorm.load(
-            prefix=f"{prefix}.ln", weights=weights, eps=config.layer_norm_epsilon
-        )
-        self.linear = TensorParallelAdapterRowLinear.load(TensorParallelHead.load(
-            config,
-            prefix=f"{prefix}.linear",
-            weights=weights,
-        ), 0, LM_HEAD, process_group=weights.process_group)
-    
-    def forward(self, hidden_states, adapter_data):
-        hidden_states, _ = self.ln(hidden_states)
-        hidden_states = self.linear(hidden_states, adapter_data)
+        
+        hidden_states, _ = self.final_layernorm(hidden_states)
         return hidden_states
 
 
@@ -359,8 +345,12 @@ class FlashPhiForCausalLM(torch.nn.Module):
     def __init__(self, config, weights):
         super().__init__()
 
-        self.transformer = FlashPhiModel(config, weights)
-        self.lm_head = PhiCausalLMHead(config, weights)
+        self.model = FlashPhiModel(config, weights)
+        self.lm_head = TensorParallelAdapterRowLinear.load(TensorParallelHead.load(
+            config,
+            prefix="lm_head",
+            weights=weights,
+        ), 0, LM_HEAD, process_group=weights.process_group)
 
     def forward(
         self,
@@ -375,7 +365,7 @@ class FlashPhiForCausalLM(torch.nn.Module):
         adapter_data: AdapterBatchData,
         lm_head_indices: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        hidden_states = self.transformer(
+        hidden_states = self.model(
             input_ids,
             position_ids,
             cu_seqlen_prefill,

--- a/server/lorax_server/models/flash_phi.py
+++ b/server/lorax_server/models/flash_phi.py
@@ -8,8 +8,10 @@ from typing import Dict, List, Optional, Tuple
 
 from lorax_server.models import FlashCausalLM
 from lorax_server.models.custom_modeling.flash_phi_modeling import (
-    ATTN_WQKV,
-    ATTN_OUT_PROJ,
+    ATTN_Q_PROJ,
+    ATTN_K_PROJ,
+    ATTN_V_PROJ,
+    ATTN_DENSE,
     MLP_FC1,
     MLP_FC2,
     FlashPhiForCausalLM,
@@ -28,8 +30,8 @@ from lorax_server.utils.weights import shard_on_dim
 tracer = trace.get_tracer(__name__)
 
 
-ADAPTER_LAYERS = [ATTN_WQKV, ATTN_OUT_PROJ, MLP_FC1, MLP_FC2, LM_HEAD]
-ROW_PARALLEL = {ATTN_OUT_PROJ, MLP_FC2, LM_HEAD}
+ADAPTER_LAYERS = [ATTN_Q_PROJ, ATTN_K_PROJ, ATTN_V_PROJ, ATTN_DENSE, MLP_FC1, MLP_FC2, LM_HEAD]
+ROW_PARALLEL = {ATTN_DENSE, MLP_FC2, LM_HEAD}
 
 
 class FlashPhi(FlashCausalLM):
@@ -103,9 +105,9 @@ class FlashPhi(FlashCausalLM):
             model_id=model_id,
             model=model,
             tokenizer=tokenizer,
-            num_layers=len(model.transformer.h),
-            num_kv_heads=model.transformer.num_key_value_heads,
-            head_size=model.transformer.head_size,
+            num_layers=len(model.model.layers),
+            num_kv_heads=model.model.num_key_value_heads,
+            head_size=model.model.head_size,
             dtype=dtype,
             device=device,
             rank=rank,
@@ -122,15 +124,17 @@ class FlashPhi(FlashCausalLM):
     def adapter_target_to_layer(self) -> Dict[str, Tuple[str, torch.Tensor]]:
         layer_weights = {}
 
-        prefix = "transformer.h"
-        for i, layer in enumerate(self.model.transformer.h):
-            layer_weights[(i, ATTN_WQKV)] = (f"{prefix}.{i}.mixer.Wqkv", layer.mixer.Wqkv)
-            layer_weights[(i, ATTN_OUT_PROJ)] = (f"{prefix}.{i}.mixer.out_proj", layer.mixer.out_proj)
+        prefix = "model.layers"
+        for i, layer in enumerate(self.model.model.layers):
+            layer_weights[(i, ATTN_Q_PROJ)] = (f"{prefix}.{i}.self_attn.q_proj", layer.self_attn.qkv_proj)
+            layer_weights[(i, ATTN_K_PROJ)] = (f"{prefix}.{i}.self_attn.k_proj", layer.self_attn.qkv_proj)
+            layer_weights[(i, ATTN_V_PROJ)] = (f"{prefix}.{i}.self_attn.v_proj", layer.self_attn.qkv_proj)
+            layer_weights[(i, ATTN_DENSE)] = (f"{prefix}.{i}.self_attn.dense", layer.self_attn.dense)
 
             layer_weights[(i, MLP_FC1)] = (f"{prefix}.{i}.mlp.fc1", layer.mlp.fc1)
             layer_weights[(i, MLP_FC2)] = (f"{prefix}.{i}.mlp.fc2", layer.mlp.fc2)
         
-        layer_weights[(0, LM_HEAD)] = ("lm_head.linear", self.model.lm_head.linear)
+        layer_weights[(0, LM_HEAD)] = ("lm_head", self.model.lm_head)
         return layer_weights
     
     @property
@@ -138,56 +142,7 @@ class FlashPhi(FlashCausalLM):
         return ADAPTER_LAYERS
     
     def get_num_layers_for_type(self, layer_type: str) -> int:
-        return 1 if layer_type == LM_HEAD else len(self.model.transformer.h)
+        return 1 if layer_type == LM_HEAD else len(self.model.model.layers)
     
     def is_row_parallel(self, layer_type: str) -> bool:
         return layer_type in ROW_PARALLEL
-    
-    def split_lora_b_qkv(self, t: torch.Tensor, head_size: int, num_heads: int, num_key_value_heads: int) -> torch.Tensor:
-        # Because we're splitting on the hidden size dimension, we need to
-        # account for the separate q, k, and v matrices.
-        chunks = t.split(
-            [
-                head_size * num_heads,
-                head_size * num_key_value_heads,
-                head_size * num_key_value_heads,
-            ],
-            dim=1,
-        )
-        assert len(chunks) == 3
-        chunks = [
-            shard_on_dim(w, dim=1, process_group=self.process_group)
-            for w in chunks
-        ]
-        return torch.cat(chunks, dim=1)
-    
-    def shard_lora_weights(
-        self,
-        weights_a: List[torch.Tensor],
-        weights_b: List[torch.Tensor],
-        layer_type: str,
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-        # TODO(travis): genralize this for other layers and architectures
-        if layer_type == ATTN_WQKV:
-            # [hidden_size, r]
-            split_dim = 0 if self.is_row_parallel(layer_type) else 1
-            weights_a = [
-                shard_on_dim(w, dim=split_dim, process_group=self.process_group)
-                for w in weights_a
-            ]
-
-            # [r, hidden_size]
-            # Because we're splitting on the hidden size dimension, we need to
-            # account for the separate q, k, and v matrices.
-            num_heads = self.config.n_head
-            hidden_size = self.config.n_embd
-            head_size = hidden_size // num_heads
-            num_key_value_heads = getattr(self.config, "n_head_kv", None) or num_heads
-            weights_b = [
-                self.split_lora_b_qkv(w, head_size, num_heads, num_key_value_heads)
-                for w in weights_b
-            ]
-
-            return weights_a, weights_b
-        else:
-            return super().shard_lora_weights(weights_a, weights_b, layer_type)


### PR DESCRIPTION
Phi-2 weights were recently updated to conform to more standard format. This PR updates our implementation to the latest in https://huggingface.co/microsoft/phi-2.

NOTE: this implementation is breaking for LoRA adapters trained on the prior version of the model.