### PR TITLE
enh: Enable JSON guided generation via OpenAI-compatible API

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -10,7 +10,7 @@ from lorax.types import (
     Response,
     Request,
     Parameters,
-    MergedAdapters,
+    MergedAdapters, ResponseFormat,
 )
 from lorax.errors import parse_error
 
@@ -79,7 +79,7 @@ class Client:
         truncate: Optional[int] = None,
         typical_p: Optional[float] = None,
         watermark: bool = False,
-        schema: Optional[Dict[str, Any]] = None,
+        response_format: Optional[ResponseFormat] = None,
         decoder_input_details: bool = False,
     ) -> Response:
         """
@@ -125,8 +125,17 @@ class Client:
                 See [Typical Decoding for Natural Language Generation](https://arxiv.org/abs/2202.00666) for more information
             watermark (`bool`):
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
-            schema (`Optional[Dict[str, Any]]`):
-                Optional JSON schema to validate the response
+            response_format (`Optional[Dict[str, Any]]`):
+                Optional specification of a format to impose upon the generated text, e.g.,:
+                ```
+                {
+                    "type": "json_object",
+                    "schema": {
+                        "type": "string",
+                        "title": "response"
+                    }
+                }
+                ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
 
@@ -153,7 +162,7 @@ class Client:
             truncate=truncate,
             typical_p=typical_p,
             watermark=watermark,
-            schema=json.dumps(schema) if schema is not None else None,
+            response_format=response_format, # TODO: make object, ensure all variants of generate are migrated
             decoder_input_details=decoder_input_details,
         )
         request = Request(inputs=prompt, stream=False, parameters=parameters)
@@ -165,6 +174,10 @@ class Client:
             cookies=self.cookies,
             timeout=self.timeout,
         )
+
+        # TODO: handle 422 errors
+        print(resp.text) # Failed to deserialize the JSON body into the target type: parameters.response_format: missing field `type` at line 1 column 854
+
         payload = resp.json()
         if resp.status_code != 200:
             raise parse_error(resp.status_code, payload)
@@ -190,7 +203,7 @@ class Client:
         truncate: Optional[int] = None,
         typical_p: Optional[float] = None,
         watermark: bool = False,
-        schema: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Iterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens
@@ -233,8 +246,17 @@ class Client:
                 See [Typical Decoding for Natural Language Generation](https://arxiv.org/abs/2202.00666) for more information
             watermark (`bool`):
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
-            schema (`Optional[Dict[str, Any]]`):
-                Optional JSON schema to validate the response
+            response_format (`Optional[Dict[str, Any]]`):
+                Optional specification of a format to impose upon the generated text, e.g.,:
+                ```
+                {
+                    "type": "json_object",
+                    "schema": {
+                        "type": "string",
+                        "title": "response"
+                    }
+                }
+                ```
 
         Returns:
             Iterator[StreamResponse]: stream of generated tokens
@@ -260,7 +282,7 @@ class Client:
             truncate=truncate,
             typical_p=typical_p,
             watermark=watermark,
-            schema=json.dumps(schema) if schema is not None else None,
+            response_format=json.dumps(response_format) if response_format is not None else None,
         )
         request = Request(inputs=prompt, stream=True, parameters=parameters)
 
@@ -362,7 +384,7 @@ class AsyncClient:
         truncate: Optional[int] = None,
         typical_p: Optional[float] = None,
         watermark: bool = False,
-        schema: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
         decoder_input_details: bool = False,
     ) -> Response:
         """
@@ -408,8 +430,17 @@ class AsyncClient:
                 See [Typical Decoding for Natural Language Generation](https://arxiv.org/abs/2202.00666) for more information
             watermark (`bool`):
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
-            schema (`Optional[Dict[str, Any]]`):
-                Optional JSON schema to validate the response
+            response_format (`Optional[Dict[str, Any]]`):
+                Optional specification of a format to impose upon the generated text, e.g.,:
+                ```
+                {
+                    "type": "json_object",
+                    "schema": {
+                        "type": "string",
+                        "title": "response"
+                    }
+                }
+                ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
 
@@ -437,7 +468,7 @@ class AsyncClient:
             truncate=truncate,
             typical_p=typical_p,
             watermark=watermark,
-            schema=json.dumps(schema) if schema is not None else None,
+            response_format=json.dumps(response_format) if response_format is not None else None,
         )
         request = Request(inputs=prompt, stream=False, parameters=parameters)
 
@@ -470,7 +501,7 @@ class AsyncClient:
         truncate: Optional[int] = None,
         typical_p: Optional[float] = None,
         watermark: bool = False,
-        schema: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> AsyncIterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens asynchronously
@@ -513,8 +544,17 @@ class AsyncClient:
                 See [Typical Decoding for Natural Language Generation](https://arxiv.org/abs/2202.00666) for more information
             watermark (`bool`):
                 Watermarking with [A Watermark for Large Language Models](https://arxiv.org/abs/2301.10226)
-            schema (`Optional[Dict[str, Any]]`):
-                Optional JSON schema to validate the response
+            response_format (`Optional[Dict[str, Any]]`):
+                Optional specification of a format to impose upon the generated text, e.g.,:
+                ```
+                {
+                    "type": "json_object",
+                    "schema": {
+                        "type": "string",
+                        "title": "response"
+                    }
+                }
+                ```
 
         Returns:
             AsyncIterator[StreamResponse]: stream of generated tokens
@@ -540,6 +580,7 @@ class AsyncClient:
             truncate=truncate,
             typical_p=typical_p,
             watermark=watermark,
+            response_format=json.dumps(response_format) if response_format is not None else None,
         )
         request = Request(inputs=prompt, stream=True, parameters=parameters)
 

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -1,6 +1,6 @@
 from enum import Enum
-from pydantic import BaseModel, validator, Field
-from typing import Optional, List
+from pydantic import BaseModel, validator, Field, ConfigDict
+from typing import Optional, List, Dict, Any
 
 from lorax.errors import ValidationError
 
@@ -56,6 +56,17 @@ class MergedAdapters(BaseModel):
         return v
 
 
+class ResponseFormatType(str, Enum):
+    json_object = "json_object"
+
+
+class ResponseFormat(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+    type: ResponseFormatType
+    schema_spec: Dict[str, Any] = Field(alias="schema")
+
+
 class Parameters(BaseModel):
     # The ID of the adapter to use
     adapter_id: Optional[str]
@@ -98,8 +109,8 @@ class Parameters(BaseModel):
     details: bool = False
     # Get decoder input token logprobs and ids
     decoder_input_details: bool = False
-    # Optional JSON schema string to constrain the generated text
-    json_schema: Optional[str] = Field(alias="schema")
+    # Optional response format specification to constrain the generated text
+    response_format: Optional[ResponseFormat]
 
     @validator("adapter_id")
     def valid_adapter_id(cls, v, values):

--- a/docs/guides/guided_generation.md
+++ b/docs/guides/guided_generation.md
@@ -108,16 +108,6 @@ resp = client.chat.completions.create(
 )
 
 print("Response:", resp[0].choices[0].message.content)
-
-# Legacy Completions API
-resp = client.completions.create(
-    model=adapter_id,
-    prompt="Generate a new character for my awesome game: name, age (between 1 and 99), armor and strength. ",
-    max_tokens=100,
-    response_format={"type": "json_object", "schema": schema}
-)
-
-print("Response:", resp[0].choices[0].message.content)
 ```
 
 

--- a/docs/guides/guided_generation.md
+++ b/docs/guides/guided_generation.md
@@ -62,15 +62,15 @@ schema = {
     "type": "object"
 }
 
-# Now simply pass this schema along when sending a generate request:
+# Now simply pass this schema in the `response_format` parameter when sending a generate request:
 prompt = "Generate a new character for my awesome game: name, age (between 1 and 99), armor and strength. "
-response = client.generate(prompt, schema=schema)
+response = client.generate(prompt, response_format={"type": "json_object", "schema": schema})
 print(response.generated_text)
 ```
 
 ### OpenAI-compatible API
 
-Guided generation of JSON following a schema is supported with the `response_format` parameter.
+Guided generation of JSON following a schema is supported via the `response_format` parameter.
 
 NOTE: Currently a schema is REQUIRED. This differs from the existing OpenAI JSON mode, in which no schema is supported.
 
@@ -104,7 +104,7 @@ resp = client.chat.completions.create(
         },
     ],
     max_tokens=100,
-    response_format={"type": "json_object", "schema": schema}
+    response_format={"type": "json_object", "schema": schema},
 )
 
 print("Response:", resp[0].choices[0].message.content)

--- a/docs/guides/guided_generation.md
+++ b/docs/guides/guided_generation.md
@@ -34,6 +34,8 @@ valid next tokens using this FSM and sets the probability of invalid tokens to -
 This example follows the [JSON-guided generation example](https://outlines-dev.github.io/outlines/quickstart/#json-guided-generation) in the Outlines quickstart.
 
 We assume that you have already deployed LoRAX using a suitable base model and installed the [LoRAX Python Client](../reference/python_client.md).
+Alternatively, see [below](guided_generation.md#openai-compatible-api) for an example of guided generation using an 
+OpenAI client.
 
 ```python
 from lorax import Client
@@ -65,3 +67,57 @@ prompt = "Generate a new character for my awesome game: name, age (between 1 and
 response = client.generate(prompt, schema=schema)
 print(response.generated_text)
 ```
+
+### OpenAI-compatible API
+
+Guided generation of JSON following a schema is supported with the `response_format` parameter.
+
+NOTE: Currently a schema is REQUIRED. This differs from the existing OpenAI JSON mode, in which no schema is supported.
+
+```python
+schema = {
+    "$defs": {
+        "Armor": {
+            "enum": ["leather", "chainmail", "plate"],
+            "title": "Armor",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "name": {"maxLength": 10, "title": "Name", "type": "string"},
+        "age": {"title": "Age", "type": "integer"},
+        "armor": {"$ref": "#/$defs/Armor"},
+        "strength": {"title": "Strength", "type": "integer"}
+    },
+    "required": ["name", "age", "armor", "strength"],
+    "title": "Character",
+    "type": "object"
+}
+
+# Chat Completions API
+resp = client.chat.completions.create(
+    model=adapter_id,
+    messages=[
+        {
+            "role": "user",
+            "content": "Generate a new character for my awesome game: name, age (between 1 and 99), armor and strength. ",
+        },
+    ],
+    max_tokens=100,
+    response_format={"type": "json_object", "schema": schema}
+)
+
+print("Response:", resp[0].choices[0].message.content)
+
+# Legacy Completions API
+resp = client.completions.create(
+    model=adapter_id,
+    prompt="Generate a new character for my awesome game: name, age (between 1 and 99), armor and strength. ",
+    max_tokens=100,
+    response_format={"type": "json_object", "schema": schema}
+)
+
+print("Response:", resp[0].choices[0].message.content)
+```
+
+

--- a/docs/guides/openai_api.md
+++ b/docs/guides/openai_api.md
@@ -51,6 +51,10 @@ for message in messages:
     print(message)
 ```
 
+### Guided Generation (JSON Mode)
+
+See [here](guided_generation.md#openai-compatible-api) for an example.
+
 ### REST API
 
 The REST API can be used directly in addition to the Python SDK:
@@ -98,7 +102,7 @@ client = OpenAI(
     base_url="http://127.0.0.1:8080/v1",
 )
 
-# synchrounous completions
+# synchronous completions
 completion = client.completions.create(
     model=adapter_id,
     prompt=prompt,
@@ -116,7 +120,11 @@ for message in completion_stream:
     print("Completion message:", message)
 ```
 
-REST:
+### Guided Generation (JSON Mode)
+
+See [here](guided_generation.md#openai-compatible-api) for an example.
+
+### REST API
 
 ```bash
 curl http://127.0.0.1:8080/v1/completions \

--- a/docs/guides/openai_api.md
+++ b/docs/guides/openai_api.md
@@ -122,7 +122,7 @@ for message in completion_stream:
 
 ### Guided Generation (JSON Mode)
 
-See [here](guided_generation.md#openai-compatible-api) for an example.
+JSON mode is not supported in the legacy completions API. Please use the Chat Completions API above instead.
 
 ### REST API
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -434,7 +434,7 @@ enum ResponseFormatType {
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 struct ResponseFormat {
     r#type: ResponseFormatType,
-    schema: serde_json::Value,  // TODO: make this optional once arbitrary JSON object is supported in Outlines
+    schema: serde_json::Value, // TODO: make this optional once arbitrary JSON object is supported in Outlines
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
@@ -456,7 +456,6 @@ struct ChatCompletionRequest {
     // TODO(travis): add other LoRAX params here
     response_format: Option<ResponseFormat>,
 }
-
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 struct CompletionRequest {
@@ -582,8 +581,8 @@ impl From<CompletionRequest> for CompatGenerateRequest {
     fn from(req: CompletionRequest) -> Self {
         let mut schema: Option<String> = None;
         if req.response_format.is_some() {
-          let response_format = req.response_format.unwrap();
-          schema = Some(response_format.schema.to_string())
+            let response_format = req.response_format.unwrap();
+            schema = Some(response_format.schema.to_string())
         }
 
         CompatGenerateRequest {
@@ -623,8 +622,8 @@ impl From<ChatCompletionRequest> for CompatGenerateRequest {
     fn from(req: ChatCompletionRequest) -> Self {
         let mut schema: Option<String> = None;
         if req.response_format.is_some() {
-          let response_format = req.response_format.unwrap();
-          schema = Some(response_format.schema.to_string())
+            let response_format = req.response_format.unwrap();
+            schema = Some(response_format.schema.to_string())
         }
 
         CompatGenerateRequest {

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -579,12 +579,6 @@ pub(crate) enum CompletionFinishReason {
 
 impl From<CompletionRequest> for CompatGenerateRequest {
     fn from(req: CompletionRequest) -> Self {
-        let mut schema: Option<String> = None;
-        if req.response_format.is_some() {
-            let response_format = req.response_format.unwrap();
-            schema = Some(response_format.schema.to_string())
-        }
-
         CompatGenerateRequest {
             inputs: req.prompt,
             parameters: GenerateParameters {
@@ -611,7 +605,7 @@ impl From<CompletionRequest> for CompatGenerateRequest {
                 decoder_input_details: req.logprobs.is_some(),
                 apply_chat_template: false,
                 seed: None,
-                schema: schema,
+                schema: None,
             },
             stream: req.stream.unwrap_or(false),
         }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -254,9 +254,9 @@ pub(crate) struct GenerateParameters {
     #[schema(
         nullable = true,
         default = "null",
-        example = "{\"type\": \"string\", \"title\": \"response\"}"
+        example = json!(r#"{"type": "json_object", "schema": {type": "string", "title": "response"}}"#)
     )]
-    pub schema: Option<String>,
+    pub response_format: Option<ResponseFormat>,
 }
 
 fn default_max_new_tokens() -> u32 {
@@ -285,7 +285,7 @@ fn default_parameters() -> GenerateParameters {
         decoder_input_details: false,
         apply_chat_template: false,
         seed: None,
-        schema: None,
+        response_format: None,
     }
 }
 
@@ -605,7 +605,7 @@ impl From<CompletionRequest> for CompatGenerateRequest {
                 decoder_input_details: req.logprobs.is_some(),
                 apply_chat_template: false,
                 seed: None,
-                schema: None,
+                response_format: None,
             },
             stream: req.stream.unwrap_or(false),
         }
@@ -614,12 +614,6 @@ impl From<CompletionRequest> for CompatGenerateRequest {
 
 impl From<ChatCompletionRequest> for CompatGenerateRequest {
     fn from(req: ChatCompletionRequest) -> Self {
-        let mut schema: Option<String> = None;
-        if req.response_format.is_some() {
-            let response_format = req.response_format.unwrap();
-            schema = Some(response_format.schema.to_string())
-        }
-
         CompatGenerateRequest {
             inputs: serde_json::to_string(&req.messages).unwrap(),
             parameters: GenerateParameters {
@@ -646,7 +640,7 @@ impl From<ChatCompletionRequest> for CompatGenerateRequest {
                 decoder_input_details: false,
                 apply_chat_template: true,
                 seed: None,
-                schema: schema,
+                response_format: req.response_format,
             },
             stream: req.stream.unwrap_or(false),
         }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -478,7 +478,6 @@ struct CompletionRequest {
     user: Option<String>,
     // Additional parameters
     // TODO(travis): add other LoRAX params here
-    response_format: Option<ResponseFormat>,
 }
 
 #[derive(Serialize, ToSchema)]

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -14,6 +14,7 @@ use infer::Infer;
 use loader::AdapterLoader;
 use queue::Entry;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use utoipa::ToSchema;
 use validation::Validation;
 
@@ -441,6 +442,18 @@ struct ChatCompletionRequest {
     user: Option<String>,
     // Additional parameters
     // TODO(travis): add other LoRAX params here
+    response_format: Option<std::collections::HashMap<String, >
+}
+
+enum ResponseFormatType {
+    #[serde(alias = "json_object")]
+    JsonObject,
+    // TODO: default value?
+}
+
+struct ResponseFormat {
+    type: ResponseFormatType,
+    schema: serde::Value;
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -429,13 +429,12 @@ struct UsageInfo {
 enum ResponseFormatType {
     #[serde(alias = "json_object")]
     JsonObject,
-    // TODO: default value?
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
 struct ResponseFormat {
     r#type: ResponseFormatType,
-    schema: Option<serde_json::Value>,
+    schema: serde_json::Value,  // TODO: make this optional once arbitrary JSON object is supported in Outlines
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
@@ -584,12 +583,7 @@ impl From<CompletionRequest> for CompatGenerateRequest {
         let mut schema: Option<String> = None;
         if req.response_format.is_some() {
           let response_format = req.response_format.unwrap();
-//           schema = Some(match response_format.schema {
-//               Some(s) => s.to_string(),
-//               None => r#"{ "type": "object" }"#.to_string(),
-//           })
-
-          schema = Some(response_format.schema.unwrap_or(json!({ "type": "object" })).to_string())
+          schema = Some(response_format.schema.to_string())
         }
 
         CompatGenerateRequest {
@@ -630,12 +624,7 @@ impl From<ChatCompletionRequest> for CompatGenerateRequest {
         let mut schema: Option<String> = None;
         if req.response_format.is_some() {
           let response_format = req.response_format.unwrap();
-//           schema = Some(match response_format.schema {
-//               Some(s) => s.to_string(),
-//               None => r#"{ "type": "object" }"#.to_string(),
-//           })
-
-          schema = Some(response_format.schema.unwrap_or(json!({ "type": "object" })).to_string())
+          schema = Some(response_format.schema.to_string())
         }
 
         CompatGenerateRequest {

--- a/router/src/validation.rs
+++ b/router/src/validation.rs
@@ -147,7 +147,7 @@ impl Validation {
             adapter_parameters,
             decoder_input_details,
             apply_chat_template,
-            schema,
+            response_format,
             ..
         } = request.parameters;
 
@@ -263,6 +263,12 @@ impl Validation {
         let (inputs, input_length) = self
             .validate_input(request.inputs, truncate, max_new_tokens)
             .await?;
+
+        let mut schema: Option<String> = None;
+        if response_format.is_some() {
+            let response_format_val = response_format.unwrap();
+            schema = Some(response_format_val.schema.to_string())
+        }
 
         let parameters = NextTokenChooserParameters {
             temperature,


### PR DESCRIPTION
# What does this PR do?

* Enables using guided generation for JSON with the OpenAI client
* Updates the LoRAX client to also use the more extensible `response_format` parameter for configuring guided generation
* Updates docs

Follow up enhancement for #176.
