### PR TITLE
Pad LoRA ranks to ensure compatibility with SGMV kernel

### DIFF
--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -139,7 +139,6 @@ class BatchedLoraWeights:
         """
         first_weights = list(self.lora_weights.values())[0]
         device = first_weights.weights_a.device
-        dtype = first_weights.weights_a.dtype
         segment_indices = meta.segment_indices
 
         lora_a = {
@@ -185,12 +184,16 @@ class BatchedLoraWeights:
         for segment_idx, adapter_idx in enumerate(segment_indices):
             if adapter_idx not in self.lora_weights:
                 continue
-            rank_indices[self.lora_weights[adapter_idx].adapter_config.r].append(segment_idx)
+            rank_indices[self.lora_weights[adapter_idx].weights_a.size(2)].append(segment_idx)
 
         rank_data = {}
         for rank, indices in rank_indices.items():
             lora_a_ptr_indices = lora_a_ptr[indices]
-            tmp_shrink, tmp_expand = get_tmp_tensors(lora_a_ptr_indices.size(0), rank, device)
+            tmp_shrink, tmp_expand = get_tmp_tensors(
+                lora_a_ptr_indices.size(0),
+                rank,
+                device
+            )
 
             rank_data[rank] = RankSegments(
                 rank=rank,

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -6,7 +6,7 @@ import torch
 from peft import LoraConfig
 from torch.distributed import ProcessGroup
 
-from lorax_server.utils.sgmv import MIN_SGMV_RANK, get_tmp_tensors, orient_for_rank
+from lorax_server.utils.sgmv import MIN_SGMV_RANK, get_tmp_tensors, orient_for_rank, pad_rank
 
 
 # Constants
@@ -97,6 +97,7 @@ class MergedLoraWeights:
         adapter_config: LoraConfig,
     ):
         # [num_layers, hidden_size, r]
+        weights_a = [pad_rank(w, dim=1) for w in weights_a]
         weights_a = [
             orient_for_rank(w, adapter_config.r).contiguous()
             for w in weights_a
@@ -104,6 +105,7 @@ class MergedLoraWeights:
         self.weights_a = torch.stack(weights_a)
 
         # [num_layers, r, hidden_size]
+        weights_b = [pad_rank(w, dim=0) for w in weights_b]
         self.weights_b = torch.stack(weights_b)
 
         self.adapter_config = adapter_config

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -6,7 +6,7 @@ import torch
 from peft import LoraConfig
 from torch.distributed import ProcessGroup
 
-from lorax_server.utils.sgmv import MIN_SGMV_RANK, get_tmp_tensors, orient_for_rank
+from lorax_server.utils.sgmv import MAX_RANK_CUSTOM, get_tmp_tensors, orient_for_rank
 
 
 # Constants
@@ -47,7 +47,7 @@ class AdapterWeightData:
     
     def can_vectorize(self, pg: ProcessGroup) -> bool:
         return all(
-            rank_data.rank // pg.size() >= MIN_SGMV_RANK
+            rank_data.rank // pg.size() <= MAX_RANK_CUSTOM
             for rank_data in self.rank_data.values()
         )
     

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -6,7 +6,7 @@ import torch
 from peft import LoraConfig
 from torch.distributed import ProcessGroup
 
-from lorax_server.utils.sgmv import MIN_SGMV_RANK, get_tmp_tensors, orient_for_rank, pad_rank
+from lorax_server.utils.sgmv import MIN_SGMV_RANK, get_tmp_tensors, orient_for_rank
 
 
 # Constants
@@ -97,7 +97,6 @@ class MergedLoraWeights:
         adapter_config: LoraConfig,
     ):
         # [num_layers, hidden_size, r]
-        weights_a = [pad_rank(w, dim=1) for w in weights_a]
         weights_a = [
             orient_for_rank(w, adapter_config.r).contiguous()
             for w in weights_a
@@ -105,7 +104,6 @@ class MergedLoraWeights:
         self.weights_a = torch.stack(weights_a)
 
         # [num_layers, r, hidden_size]
-        weights_b = [pad_rank(w, dim=0) for w in weights_b]
         self.weights_b = torch.stack(weights_b)
 
         self.adapter_config = adapter_config

--- a/server/tests/utils/test_sgmv.py
+++ b/server/tests/utils/test_sgmv.py
@@ -7,6 +7,7 @@ from lorax_server.utils.sgmv import (
     lora_a_sgmv_cutlass,
     lora_b_sgmv_cutlass,
     has_sgmv,
+    pad_rank,
     use_cutlass_shrink,
 )
 
@@ -101,3 +102,7 @@ def test_add_lora_sgmv(lora_rank: int, segments: Tuple[List[int], List[int]]):
     graph.replay()
 
     assert torch.allclose(y_ours, y_ours_graph, rtol=1e-2, atol=1e-3)
+
+
+def test_pad_rank():
+    pass


### PR DESCRIPTION
Closes #78 
Closes #241

SGMV implementation requires rank >= 8 and multiple of 16 when > 8.