### PR TITLE
Pass details param into client 

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -81,6 +81,7 @@ class Client:
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
         decoder_input_details: bool = False,
+        generated_token_details: bool = True,
     ) -> Response:
         """
         Given a prompt, generate the following text
@@ -138,6 +139,8 @@ class Client:
                 ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
+            generated_token_details (`bool`):
+                Return the token logprobs and ids for generated tokens
 
         Returns:
             Response: generated response
@@ -149,7 +152,7 @@ class Client:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=best_of,
-            details=True,
+            details=generated_token_details,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
@@ -202,6 +205,7 @@ class Client:
         typical_p: Optional[float] = None,
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
+        generated_token_details: bool = True,
     ) -> Iterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens
@@ -255,6 +259,8 @@ class Client:
                     }
                 }
                 ```
+            generated_token_details (`bool`):
+                Return the token logprobs and ids for generated tokens
 
         Returns:
             Iterator[StreamResponse]: stream of generated tokens
@@ -266,7 +272,7 @@ class Client:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=None,
-            details=True,
+            details=generated_token_details,
             decoder_input_details=False,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
@@ -384,6 +390,7 @@ class AsyncClient:
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
         decoder_input_details: bool = False,
+        generated_token_details: bool = True,
     ) -> Response:
         """
         Given a prompt, generate the following text asynchronously
@@ -441,6 +448,8 @@ class AsyncClient:
                 ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
+            generated_token_details (`bool`):
+                Return the token logprobs and ids for generated tokens
 
         Returns:
             Response: generated response
@@ -452,7 +461,7 @@ class AsyncClient:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=best_of,
-            details=True,
+            details=generated_token_details,
             decoder_input_details=decoder_input_details,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
@@ -500,6 +509,7 @@ class AsyncClient:
         typical_p: Optional[float] = None,
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
+        generated_token_details: bool = True,
     ) -> AsyncIterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens asynchronously
@@ -553,6 +563,8 @@ class AsyncClient:
                     }
                 }
                 ```
+            generated_token_details (`bool`):
+                Return the token logprobs and ids for generated tokens
 
         Returns:
             AsyncIterator[StreamResponse]: stream of generated tokens
@@ -564,7 +576,7 @@ class AsyncClient:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=None,
-            details=True,
+            details=generated_token_details,
             decoder_input_details=False,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,

--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -81,7 +81,7 @@ class Client:
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
         decoder_input_details: bool = False,
-        generated_token_details: bool = True,
+        details: bool = True,
     ) -> Response:
         """
         Given a prompt, generate the following text
@@ -139,7 +139,7 @@ class Client:
                 ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
-            generated_token_details (`bool`):
+            details (`bool`):
                 Return the token logprobs and ids for generated tokens
 
         Returns:
@@ -152,7 +152,7 @@ class Client:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=best_of,
-            details=generated_token_details,
+            details=details,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
             repetition_penalty=repetition_penalty,
@@ -205,7 +205,7 @@ class Client:
         typical_p: Optional[float] = None,
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
-        generated_token_details: bool = True,
+        details: bool = True,
     ) -> Iterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens
@@ -259,7 +259,7 @@ class Client:
                     }
                 }
                 ```
-            generated_token_details (`bool`):
+            details (`bool`):
                 Return the token logprobs and ids for generated tokens
 
         Returns:
@@ -272,7 +272,7 @@ class Client:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=None,
-            details=generated_token_details,
+            details=details,
             decoder_input_details=False,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
@@ -390,7 +390,7 @@ class AsyncClient:
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
         decoder_input_details: bool = False,
-        generated_token_details: bool = True,
+        details: bool = True,
     ) -> Response:
         """
         Given a prompt, generate the following text asynchronously
@@ -448,7 +448,7 @@ class AsyncClient:
                 ```
             decoder_input_details (`bool`):
                 Return the decoder input token logprobs and ids
-            generated_token_details (`bool`):
+            details (`bool`):
                 Return the token logprobs and ids for generated tokens
 
         Returns:
@@ -461,7 +461,7 @@ class AsyncClient:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=best_of,
-            details=generated_token_details,
+            details=details,
             decoder_input_details=decoder_input_details,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,
@@ -509,7 +509,7 @@ class AsyncClient:
         typical_p: Optional[float] = None,
         watermark: bool = False,
         response_format: Optional[Union[Dict[str, Any], ResponseFormat]] = None,
-        generated_token_details: bool = True,
+        details: bool = True,
     ) -> AsyncIterator[StreamResponse]:
         """
         Given a prompt, generate the following stream of tokens asynchronously
@@ -563,7 +563,7 @@ class AsyncClient:
                     }
                 }
                 ```
-            generated_token_details (`bool`):
+            details (`bool`):
                 Return the token logprobs and ids for generated tokens
 
         Returns:
@@ -576,7 +576,7 @@ class AsyncClient:
             merged_adapters=merged_adapters,
             api_token=api_token,
             best_of=None,
-            details=generated_token_details,
+            details=details,
             decoder_input_details=False,
             do_sample=do_sample,
             max_new_tokens=max_new_tokens,

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -279,7 +279,7 @@ class Details(BaseModel):
     # Decoder input tokens, empty if decoder_input_details is False
     prefill: List[InputToken]
     # Generated tokens
-    tokens: Optional[List[Token]]
+    tokens: List[Token]
     # Additional sequences when using the `best_of` parameter
     best_of_sequences: Optional[List[BestOfSequence]]
 
@@ -289,7 +289,7 @@ class Response(BaseModel):
     # Generated text
     generated_text: str
     # Generation details
-    details: Details
+    details: Optional[Details]
 
 
 # `generate_stream` details

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -279,7 +279,7 @@ class Details(BaseModel):
     # Decoder input tokens, empty if decoder_input_details is False
     prefill: List[InputToken]
     # Generated tokens
-    tokens: List[Token]
+    tokens: Optional[List[Token]]
     # Additional sequences when using the `best_of` parameter
     best_of_sequences: Optional[List[BestOfSequence]]
 


### PR DESCRIPTION
Currently we pass details=True for all client generate calls - This relaxes that constraint.