### PR TITLE
enh: Propagate bearer token from header if one exists for OpenAI-compatible endpoints

### DIFF
--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -117,11 +117,14 @@ async fn completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    match headers.get("Authorization") {
-        Some(x) => x.strip_prefix("Bearer :").and_then(|token| gen_req.parameters.api_token = token)
-        // TODO: Just for testing, don't merge
-        None => println!("headers: {headers}")
-    }
+    headers.get("Authorization").map_or((), |x| {
+        x.to_str().map_or((), |y| {
+            y.strip_prefix("Bearer :").map_or((), |token| {
+                println!("token!! {token}");
+                gen_req.parameters.api_token = Some(token.to_string());
+            })
+        })
+    });
 
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {
@@ -184,11 +187,14 @@ async fn chat_completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    match headers.get("Authorization") {
-        Some(x) => x.strip_prefix("Bearer :").and_then(|token| gen_req.parameters.api_token = token)
-        // TODO: Just for testing, don't merge
-        None => println!("headers: {headers}")
-    }
+    headers.get("Authorization").map_or((), |x| {
+        x.to_str().map_or((), |y| {
+            y.strip_prefix("Bearer :").map_or((), |token| {
+                println!("token!! {token}");
+                gen_req.parameters.api_token = Some(token.to_string());
+            })
+        })
+    });
 
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -117,15 +117,10 @@ async fn completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    println!("!!! HEADERS !!!");
-    for (k, v) in &headers {
-        println!("{0}: {1}", k.as_str(), v.to_str().unwrap_or("N/A"));
-    }
-
+    // If a bearer token was present in this request, pass the associated token along.
     let _ = headers.get("authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
             y.strip_prefix("Bearer ").map_or((), |token| {
-                println!("token!! {token}");
                 gen_req.parameters.api_token = Some(token.to_string());
             })
         })
@@ -192,15 +187,10 @@ async fn chat_completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    println!("!!! HEADERS !!!");
-    for (k, v) in &headers {
-        println!("{0}: {1}", k.as_str(), v.to_str().unwrap_or("N/A"));
-    }
-
+    // If a bearer token was present in this request, pass the associated token along.
     let _ = headers.get("authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
             y.strip_prefix("Bearer ").map_or((), |token| {
-                println!("token!! {token}");
                 gen_req.parameters.api_token = Some(token.to_string());
             })
         })

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -118,15 +118,6 @@ async fn completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-//     // If a bearer token was present in this request, pass the associated token along.
-//     let _ = req_headers.get("authorization").map_or((), |x| {
-//         x.to_str().map_or((), |y| {
-//             y.strip_prefix("Bearer ").map_or((), |token| {
-//                 gen_req.parameters.api_token = Some(token.to_string());
-//             })
-//         })
-//     });
-//
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {
         gen_req.parameters.return_full_text = Some(default_return_full_text.0)
@@ -187,15 +178,6 @@ async fn chat_completions_v1(
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
-
-    // If a bearer token was present in this request, pass the associated token along.
-//     let _ = req_headers.get("authorization").map_or((), |x| {
-//         x.to_str().map_or((), |y| {
-//             y.strip_prefix("Bearer ").map_or((), |token| {
-//                 gen_req.parameters.api_token = Some(token.to_string());
-//             })
-//         })
-//     });
 
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {
@@ -318,14 +300,14 @@ async fn generate(
     );
 
     if req.parameters.api_token.is_none() {
-      // If no API token was explicitly provided in the request payload, try to set it from the request headers.
-      let _ = req_headers.get("authorization").map_or((), |x| {
-          x.to_str().map_or((), |y| {
-              y.strip_prefix("Bearer ").map_or((), |token| {
-                  req.parameters.api_token = Some(token.to_string());
-              })
-          })
-      });
+        // If no API token was explicitly provided in the request payload, try to set it from the request headers.
+        let _ = req_headers.get("authorization").map_or((), |x| {
+            x.to_str().map_or((), |y| {
+                y.strip_prefix("Bearer ").map_or((), |token| {
+                    req.parameters.api_token = Some(token.to_string());
+                })
+            })
+        });
     }
 
     // Inference
@@ -562,14 +544,14 @@ async fn generate_stream_with_callback(
     headers.insert("X-Accel-Buffering", "no".parse().unwrap());
 
     if req.parameters.api_token.is_none() {
-      // If no API token was explicitly provided in the request payload, try to set it from the request headers.
-      let _ = req_headers.get("authorization").map_or((), |x| {
-          x.to_str().map_or((), |y| {
-              y.strip_prefix("Bearer ").map_or((), |token| {
-                  req.parameters.api_token = Some(token.to_string());
-              })
-          })
-      });
+        // If no API token was explicitly provided in the request payload, try to set it from the request headers.
+        let _ = req_headers.get("authorization").map_or((), |x| {
+            x.to_str().map_or((), |y| {
+                y.strip_prefix("Bearer ").map_or((), |token| {
+                    req.parameters.api_token = Some(token.to_string());
+                })
+            })
+        });
     }
 
     let stream = async_stream::stream! {

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -111,10 +111,17 @@ example = json ! ({"error": "Incomplete generation"})),
 async fn completions_v1(
     default_return_full_text: Extension<bool>,
     infer: Extension<Infer>,
+    headers: HeaderMap,
     req: Json<CompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
+
+    match headers.get("Authorization") {
+        Some(x) => x.strip_prefix("Bearer :").and_then(|token| gen_req.parameters.api_token = token)
+        // TODO: Just for testing, don't merge
+        None => println!("headers: {headers}")
+    }
 
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {
@@ -171,10 +178,17 @@ example = json ! ({"error": "Incomplete generation"})),
 async fn chat_completions_v1(
     default_return_full_text: Extension<bool>,
     infer: Extension<Infer>,
+    headers: HeaderMap,
     req: Json<ChatCompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
+
+    match headers.get("Authorization") {
+        Some(x) => x.strip_prefix("Bearer :").and_then(|token| gen_req.parameters.api_token = token)
+        // TODO: Just for testing, don't merge
+        None => println!("headers: {headers}")
+    }
 
     // default return_full_text given the pipeline_tag
     if gen_req.parameters.return_full_text.is_none() {

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -117,7 +117,12 @@ async fn completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    let _ = headers.get("Authorization").map_or((), |x| {
+    println!("!!! HEADERS !!!");
+    for (k, v) in &headers {
+        println!("{0}: {1}", k.as_str(), v.to_str().unwrap_or("N/A"));
+    }
+
+    let _ = headers.get("authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
             y.strip_prefix("Bearer :").map_or((), |token| {
                 println!("token!! {token}");
@@ -187,7 +192,12 @@ async fn chat_completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    headers.get("Authorization").map_or((), |x| {
+    println!("!!! HEADERS !!!");
+    for (k, v) in &headers {
+        println!("{0}: {1}", k.as_str(), v.to_str().unwrap_or("N/A"));
+    }
+
+    let _ = headers.get("Authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
             y.strip_prefix("Bearer :").map_or((), |token| {
                 println!("token!! {token}");

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -117,7 +117,7 @@ async fn completions_v1(
     let req = req.0;
     let mut gen_req = CompatGenerateRequest::from(req);
 
-    headers.get("Authorization").map_or((), |x| {
+    let _ = headers.get("Authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
             y.strip_prefix("Bearer :").map_or((), |token| {
                 println!("token!! {token}");

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -124,7 +124,7 @@ async fn completions_v1(
 
     let _ = headers.get("authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
-            y.strip_prefix("Bearer :").map_or((), |token| {
+            y.strip_prefix("Bearer ").map_or((), |token| {
                 println!("token!! {token}");
                 gen_req.parameters.api_token = Some(token.to_string());
             })
@@ -197,9 +197,9 @@ async fn chat_completions_v1(
         println!("{0}: {1}", k.as_str(), v.to_str().unwrap_or("N/A"));
     }
 
-    let _ = headers.get("Authorization").map_or((), |x| {
+    let _ = headers.get("authorization").map_or((), |x| {
         x.to_str().map_or((), |y| {
-            y.strip_prefix("Bearer :").map_or((), |token| {
+            y.strip_prefix("Bearer ").map_or((), |token| {
                 println!("token!! {token}");
                 gen_req.parameters.api_token = Some(token.to_string());
             })


### PR DESCRIPTION
Since the OpenAI client doesn't include an API token or authentication key as part of the request payload, it's useful to propagate the bearer token from the incoming request headers so that downstream calls can use it to authenticate.

Alternatively, we could support passing such a token more explicitly via an additional header, which the OpenAI client [does support](https://github.com/openai/openai-python/blob/a7115b5f33acd27326e5f78e19beb0d73bd3268e/src/openai/resources/chat/completions.py#L88). This is more expressive, but would require the user to take more action.