### PR TITLE
fix: Disallow early stopping during warmup

### DIFF
--- a/docs/reference/launcher.md
+++ b/docs/reference/launcher.md
@@ -96,7 +96,7 @@ Options:
           This is the maximum allowed input length (expressed in number of tokens) for users. The larger this value, the longer prompt users can send which can impact the overall memory required to handle the load. Please note that some models have a finite range of sequence they can handle
           
           [env: MAX_INPUT_LENGTH=]
-          [default: 1024]
+          [default: 1792]
 
       --max-total-tokens <MAX_TOTAL_TOKENS>
           This is the most important value to set as it defines the "memory budget" of running clients requests. Clients will send input sequences and ask to generate `max_new_tokens` on top. with a value of `1512` users can send either a prompt of `1000` and ask for `512` new tokens, or send a prompt of `1` and ask for `1511` max_new_tokens. The larger this value, the larger amount each request will be in your RAM and the less effective batching can be

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     max_best_of: usize,
     #[clap(default_value = "4", long, env)]
     max_stop_sequences: usize,
-    #[clap(default_value = "1024", long, env)]
+    #[clap(default_value = "1792", long, env)]
     max_input_length: usize,
     #[clap(default_value = "2048", long, env)]
     max_total_tokens: usize,


### PR DESCRIPTION
Fixes issue where instruct models can early stop during warmup resulting in a `None` batch being returned.

Also increases the default `--max-input-length` param to decrease default warmup time and support longer contexts by default.