### PR TITLE
Add support for LoRA adapters trained with Rank-Stabilized scaling

### DIFF
--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -240,7 +240,7 @@ class Model(ABC):
             lora_b, lora_b_name = module_map[weight_name]["lora_B"]
             lora_b = lora_b.to(base_device, self.dtype)
 
-            scale: float = get_scaling_factor(
+            scale = get_scaling_factor(
                 adapter_config.lora_alpha,
                 adapter_config.r,
                 uses_rslora=uses_rslora(adapter_config),

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -235,7 +235,10 @@ class Model(ABC):
             lora_b, lora_b_name = module_map[weight_name]["lora_B"]
             lora_b = lora_b.to(base_device, self.dtype)
 
-            scale = adapter_config.lora_alpha / adapter_config.r
+            if hasattr(adapter_config, "use_rslora") and adapter_config.use_rslora:
+                scale = adapter_config.lora_alpha / (adapter_config.r ** 0.5)
+            else:
+                scale = adapter_config.lora_alpha / adapter_config.r
 
             unused_weight_names.discard(lora_a_name)
             unused_weight_names.discard(lora_b_name)

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -163,7 +163,7 @@ def compute_delta_weight(
 
     Reference: https://github.com/huggingface/peft/blob/v0.4.0/src/peft/tuners/lora.py#L799-L806
     """
-    scaling = get_scaling_factor(alpha, r, uses_rslora)
+    scaling = get_scaling_factor(alpha, r, uses_rslora=uses_rslora)
     delta_weight = transpose(lora_B @ lora_A, fan_in_fan_out) * scaling
     return delta_weight
 


### PR DESCRIPTION
In PEFT 0.9, support was added for adapters trained using a new flag called `use_rslora`.

When set to True, Rank-Stabilized LoRA sets the adapter scaling factor to `lora_alpha/math.sqrt(r)`, since it was proven to work better. Otherwise, it will use the original default value of `lora_alpha/r`.

In equation form:

- Normal LoRA layers: `W0X + (lora_alpha/r)(BAX)` where W0 is the base model, BA are the lora weight matrices and X is the input from the embedding layer/previous transformer layer.
- LoRA layers with RSLoRA enabled: W0X + (lora_alpha/sqrt(r))(BAX)

In particular, this is useful when using larger ranks since it prevents the gradient from collapsing as rank increases, which may result in higher ranks actually leading to better performance (not true by default today and in the original LoRA paper). Paper: https://arxiv.org/pdf/2312.03732.pdf.

![image](https://github.com/predibase/lorax/assets/106701836/f0ee0225-d235-4037-860b-99e172f0bffa)
