### PR TITLE
Enforce adapters cannot be loaded past `--adapter-memory-fraction`

### DIFF
--- a/docs/reference/launcher.md
+++ b/docs/reference/launcher.md
@@ -147,7 +147,7 @@ Options:
           Maximum number of adapters that can be placed on the GPU and accept requests at a time
           
           [env: MAX_ACTIVE_ADAPTERS=]
-          [default: 128]
+          [default: 1024]
 
       --adapter-cycle-time-s <ADAPTER_CYCLE_TIME_S>
           The time in seconds between adapter exchanges

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -264,7 +264,7 @@ struct Args {
     max_waiting_tokens: usize,
 
     /// Maximum number of adapters that can be placed on the GPU and accept requests at a time.
-    #[clap(default_value = "128", long, env)]
+    #[clap(default_value = "1024", long, env)]
     max_active_adapters: usize,
 
     /// The time in seconds between adapter exchanges.

--- a/proto/generate.proto
+++ b/proto/generate.proto
@@ -288,6 +288,13 @@ message DownloadAdapterRequest {
 message DownloadAdapterResponse {
     /// True if download occurred, false if skipped
     bool downloaded = 1;
+
+    /// Fraction of the adapter memory limit consumed by the adapter.
+    /// If no limit is set, will return 0.
+    /// When the total across all loaded adapters exceeds 
+    /// the adapter_memory_fraction limit, no more adapters
+    /// will be loaded to GPU and LoRAX will begin swapping.
+    float memory_fraction = 2;
 }
 
 message LoadAdapterRequest {

--- a/router/client/src/client.rs
+++ b/router/client/src/client.rs
@@ -193,7 +193,7 @@ impl Client {
         adapter_parameters: AdapterParameters,
         adapter_source: String,
         api_token: Option<String>,
-    ) -> Result<bool> {
+    ) -> Result<DownloadAdapterResponse> {
         if let Some(adapter_source_enum) =
             AdapterSource::from_str_name(adapter_source.to_uppercase().as_str())
         {
@@ -204,7 +204,7 @@ impl Client {
             })
             .inject_context();
             let response = self.stub.download_adapter(request).await?.into_inner();
-            Ok(response.downloaded)
+            Ok(response)
         } else {
             let err_string = format!(
                 "Invalid source '{}' when downloading adapter '{}'",

--- a/router/client/src/lib.rs
+++ b/router/client/src/lib.rs
@@ -9,7 +9,7 @@ pub use client::Client;
 pub use pb::generate::v1::HealthResponse;
 pub use pb::generate::v1::InfoResponse as ShardInfo;
 pub use pb::generate::v1::{
-    AdapterParameters, Batch, CachedBatch, FinishReason, GeneratedText, Generation,
+    AdapterParameters, Batch, CachedBatch, DownloadAdapterResponse, FinishReason, GeneratedText, Generation,
     MajoritySignMethod, MergeStrategy, NextTokenChooserParameters, PrefillTokens, Request,
     StoppingCriteriaParameters,
 };

--- a/router/client/src/sharded_client.rs
+++ b/router/client/src/sharded_client.rs
@@ -1,5 +1,5 @@
 /// Multi shard Client
-use crate::{AdapterParameters, Batch, CachedBatch, Client, Generation, HealthResponse, ShardInfo};
+use crate::{AdapterParameters, Batch, CachedBatch, Client, DownloadAdapterResponse, Generation, HealthResponse, ShardInfo};
 use crate::{ClientError, Result};
 use futures::future::join_all;
 use tonic::transport::Uri;
@@ -155,7 +155,7 @@ impl ShardedClient {
         adapter_parameters: AdapterParameters,
         adapter_source: String,
         api_token: Option<String>,
-    ) -> Result<bool> {
+    ) -> Result<DownloadAdapterResponse> {
         // Only download the adapter with one client, since they share a single disk
         self.clients[0]
             .download_adapter(adapter_parameters, adapter_source, api_token)

--- a/router/src/loader.rs
+++ b/router/src/loader.rs
@@ -146,12 +146,13 @@ async fn loader_task(mut client: ShardedClient, receiver: flume::Receiver<Adapte
                     )
                     .await
                 {
-                    Ok(_) => {
+                    Ok(resp) => {
                         tracing::info!("adapter {} downloaded", adapter.as_string());
                         let mut locked_state = queues_state.lock().unwrap();
                         if locked_state.has_adapter(&adapter) {
                             // Above check guards against the case where the adapter was terminated between the initial
                             // time of request and the time of adapter download
+                            locked_state.set_cost(&adapter, resp.memory_fraction);
                             locked_state.set_status(&adapter, AdapterStatus::Downloaded);
                         }
                     }

--- a/router/src/queue.rs
+++ b/router/src/queue.rs
@@ -66,6 +66,9 @@ pub(crate) struct QueueState {
     /// Adapter status
     status: AdapterStatus,
 
+    /// Cost as a fraction of the adapter memory budget
+    cost: Option<f32>,
+
     /// Timestamp when the adapter was last activated
     activation_ts: Option<Instant>,
 
@@ -80,6 +83,7 @@ impl QueueState {
             entries: VecDeque::with_capacity(128),
             adapter,
             status,
+            cost: None,
             activation_ts: None,
             event,
         }
@@ -143,6 +147,14 @@ impl QueueState {
         &self.status
     }
 
+    pub(crate) fn set_cost(&mut self, cost: f32) {
+        self.cost = Some(cost);
+    }
+
+    pub(crate) fn cost(&self) -> Option<f32> {
+        self.cost
+    }
+
     pub(crate) fn set_activation_ts(&mut self, ts: Instant) {
         self.activation_ts = Some(ts);
     }
@@ -169,6 +181,9 @@ pub(crate) struct AdapterQueuesState {
     /// Number of adapters that can be active at a time
     max_active_adapters: usize,
 
+    /// Fraction of adapter memory budget remaining to allocate to new adapters
+    memory_budget_remaining: f32,
+
     /// Maximum time an adapter is allowed to be active before exchanging out
     max_active_time: Duration,
 
@@ -189,6 +204,7 @@ impl AdapterQueuesState {
             active_adapters,
             tracked_adapters,
             max_active_adapters: max_active_adapters,
+            memory_budget_remaining: 1.0,
             max_active_time: Duration::from_secs(adapter_cycle_time_s),
             next_id: 0,
         }
@@ -253,6 +269,17 @@ impl AdapterQueuesState {
             }
         }
         errored_adapters
+    }
+
+    pub(crate) fn set_cost(&mut self, adapter: &Adapter, cost: f32) {
+        let q = self.queue_map.get_mut(adapter);
+        if q.is_none() {
+            // TODO(travis): remove this
+            tracing::error!("adapter {} not found in queue_map", adapter.as_string());
+            println!("{:?}", Backtrace::force_capture());
+        }
+        let queue = q.unwrap();
+        queue.set_cost(cost);
     }
 
     pub(crate) fn set_status(&mut self, adapter: &Adapter, status: AdapterStatus) {
@@ -392,11 +419,25 @@ impl AdapterQueuesState {
         while self.active_adapters.len() < self.max_active_adapters
             && self.pending_adapters.len() > 0
         {
-            let adapter = self.pending_adapters.pop_front().unwrap();
+            let queue = self.queue_map.get_mut(self.pending_adapters.front().unwrap()).unwrap();
+            if queue.cost().is_none() {
+                // Adapter has not been downloaded yet
+                break;
+            }
+
+            // Check to see that we have enough memory budget remaining to load the adapter
+            let cost = queue.cost().unwrap();
+            if cost > self.memory_budget_remaining {
+                // Adapter is too expensive to load
+                break;
+            }
 
             // Update activation timestamp
-            let queue = self.queue_map.get_mut(&adapter).unwrap();
+            let adapter = self.pending_adapters.pop_front().unwrap();
             queue.set_activation_ts(now);
+
+            // Calculate remaining memory budget
+            self.memory_budget_remaining -= cost;
 
             // Start async loading process
             load_adapters.push(adapter.clone());

--- a/server/lorax_server/cli.py
+++ b/server/lorax_server/cli.py
@@ -90,6 +90,7 @@ def serve(
         model_id, adapter_id, revision, sharded, quantize, compile, dtype, trust_remote_code, uds_path, source, adapter_source
     )
 
+
 def _download_weights(
     model_id: str,
     revision: Optional[str] = None,

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -722,6 +722,10 @@ class FlashCausalLM(Model):
     @property
     def batch_type(self) -> Type[FlashCausalLMBatch]:
         return FlashCausalLMBatch
+    
+    def adapter_memory_size(self) -> int:
+        total_gpu_memory = torch.cuda.get_device_properties(self.device).total_memory
+        return ADAPTER_MEMORY_FRACTION * total_gpu_memory
 
     def warmup(self, batch: FlashCausalLMBatch, max_new_tokens: int):
         torch.cuda.empty_cache()

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -81,6 +81,9 @@ class Model(ABC):
     @abstractmethod
     def batch_type(self) -> Type[B]:
         raise NotImplementedError
+    
+    def adapter_memory_size(self) -> int:
+        return 0
 
     @abstractmethod
     def generate_token(self, batch: B) -> Tuple[List[GeneratedText], Optional[B]]:


### PR DESCRIPTION
Fixes #53.

One of the main issues with our existing adapter loading and offloading strategy is that it relies on the user setting a fixed adapter limit via `--max-active-adapters` (default: `128`). However, this doesn't account for the fact that adapter sizes can vary by orders of magnitude based on the rank. As such, the server might do well with 128 rank 8 adapters but fall over with just a handful of rank 128 adapters.

In #303, we introduced a new parameter `--adapter-memory-fraction` that allows setting aside a dedicated pool of GPU memory to account for adapter overhead. This prevents the KV cache from expanding past the reservation set aside for adapters, reducing memory pressure. However, because the LoRAX scheduler still works off of the max active adapters, this means that users can still blow up the GPU memory by setting max active adapters higher than what can be accommodated by the adapter memory fraction.

This PR reconciles the scheduler with the adapter memory fraction. Now, the LoRAX scheduler will look at the size of each adapter after download to determine whether it can be loaded safely on the GPU. If not, then the adapter will wait until enough space is freed up the other active adapters becoming idle before the adapter can be moved to the GPU. This should ensure that no CUDA OOMs occur due to loading too many adapters.

Note that with this change, the max active adapters may no longer be needed, but we will keep it around for now to avoid backwards incompatible changes. However, the new default of 1024 should be sufficiently high that it won't be used in most cases.