### PR TITLE
Log generated tokens out to file when streaming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'stream-log-dump' # XXX
     tags:
       - 'v*'
 
@@ -61,11 +62,12 @@ jobs:
         with:
           images: |
             ghcr.io/predibase/lorax
+          # XXX
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=,suffix=,format=short
-            type=raw,value=latest
+            type=sha,prefix=magdy-test-,suffix=,format=short
+            
+            
+
       
       - name: Create a hash from tags
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'stream-log-dump' # XXX
       - 'main'
     tags:
       - 'v*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'stream-log-dump' # XXX
     tags:
       - 'v*'
 
@@ -62,12 +61,11 @@ jobs:
         with:
           images: |
             ghcr.io/predibase/lorax
-          # XXX
           tags: |
-            type=sha,prefix=magdy-test-,suffix=,format=short
-            
-            
-
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=latest
       
       - name: Create a hash from tags
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - 'stream-log-dump' # XXX
       - 'main'
     tags:
       - 'v*'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,7 +170,7 @@ checksum = "771051cdc7eec2dc1b23fbf870bb7fbb89136fe374227c875e377f1eed99a429"
 dependencies = [
  "futures",
  "generational-arena",
- "parking_lot",
+ "parking_lot 0.12.1",
  "slotmap",
 ]
 
@@ -301,6 +316,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.52.3",
+]
 
 [[package]]
 name = "clap"
@@ -503,7 +530,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -1030,6 +1057,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1136,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1234,6 +1287,8 @@ dependencies = [
  "opentelemetry-otlp",
  "rand",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "serde",
  "serde_json",
  "thiserror",
@@ -1506,7 +1561,7 @@ dependencies = [
  "hyper",
  "muxado",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "regex",
  "rustls-pemfile",
  "serde",
@@ -1566,6 +1621,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1815,12 +1879,37 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2199,6 +2288,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -2214,6 +2304,55 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadced6a67c5c2d1c819cc2d7e6ddf066f32b9b6a04f8866203ceeb44b79c37f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "getrandom",
+ "http",
+ "hyper",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "task-local-extensions",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
 ]
 
 [[package]]
@@ -2663,6 +2802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,7 +2944,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3416,6 +3564,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3648,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.3",
+]
 
 [[package]]
 name = "windows-sys"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -30,6 +30,8 @@ opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.12.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.14", features = [] }
+reqwest-middleware = "0.2.4"
+reqwest-retry = "0.4.0"
 serde = "1.0.152"
 serde_json = { version = "1.0.93", features = ["preserve_order"] }
 thiserror = "1.0.38"

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -15,7 +15,6 @@ use loader::AdapterLoader;
 use queue::Entry;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use utoipa::openapi::schema;
 use utoipa::ToSchema;
 use validation::Validation;
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -15,6 +15,7 @@ use loader::AdapterLoader;
 use queue::Entry;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use utoipa::openapi::schema;
 use utoipa::ToSchema;
 use validation::Validation;
 
@@ -66,6 +67,8 @@ pub struct Info {
     pub sha: Option<&'static str>,
     #[schema(nullable = true, example = "null")]
     pub docker_label: Option<&'static str>,
+    #[schema(nullable = true, example = "http://localhost:8899")]
+    pub request_logger_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema, Default)]

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -795,7 +795,7 @@ async fn request_logger(mut rx: mpsc::Receiver<(i64, String, String)>) {
     while let Some((tokens, api_token, model_id)) = rx.recv().await {
         // Make a request out to localhost:8899 with the tokens, api_token, and model_id
         let res = client
-            .post("http://host.docker.internal:8899")
+            .post("http://localhost:8899")
             .json(&json!({"tokens": tokens, "api_token": api_token, "model_id": model_id}))
             .send()
             .await;

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -715,9 +715,6 @@ async fn generate_stream_with_callback(
                                         metrics::histogram!("lorax_request_generated_tokens", generated_text.generated_tokens as f64);
 
 
-                                        // Call a thread function that writes to a file with tenant UUID / generated number of tokens / gpu sku
-                                        request_logger_sender.send((generated_text.generated_tokens as i64, info.model_id.clone(), info.model_device_type.clone())).await;
-
 
                                         // StreamResponse
                                         end_reached = true;
@@ -729,6 +726,10 @@ async fn generate_stream_with_callback(
 
                                         tracing::debug!(parent: &span, "Output: {}", output_text);
                                         tracing::info!(parent: &span, "Success");
+
+                                        tracing::info!("!!!! SENDING INFO TO Request logger <<<<<<<<<<<<");
+                                        request_logger_sender.send((generated_text.generated_tokens as i64, info.model_id.clone(), info.model_device_type.clone())).await;
+                                        tracing::info!("!!!! SENT INFO TO Request logger <<<<<<<<<<<<");
 
                                         let stream_token = StreamResponse {
                                             token,
@@ -1002,6 +1003,7 @@ pub async fn run(
 
     // Kick off thread here that writes to the log file
     let (tx, rx) = mpsc::channel(32);
+    tracing::info!("!!!! ABOUT TO SPAWN THE REQUEST LOGGER THREAD <<<<<<<<<<<<");
     tokio::spawn(request_logger(rx));
     let request_logger_sender = Arc::new(tx);
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -795,7 +795,7 @@ async fn request_logger(mut rx: mpsc::Receiver<(i64, String, String)>) {
     while let Some((tokens, api_token, model_id)) = rx.recv().await {
         // Make a request out to localhost:8899 with the tokens, api_token, and model_id
         let res = client
-            .post("http://localhost:8899")
+            .post("http://host.docker.internal:8899")
             .json(&json!({"tokens": tokens, "api_token": api_token, "model_id": model_id}))
             .send()
             .await;

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -137,7 +137,7 @@ async fn completions_v1(
     req: Json<CompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let mut req = req.0;
-    if req.model == MODEL_ID.get().unwrap().as_str() {
+    if req.model == info.model_id.as_str() {
         // Allow user to specify the base model, but treat it as an empty adapter_id
         tracing::info!("Replacing base model {0} with empty adapter_id", req.model);
         req.model = "".to_string();
@@ -219,7 +219,7 @@ async fn chat_completions_v1(
     req: Json<ChatCompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let mut req = req.0;
-    if req.model == MODEL_ID.get().unwrap().as_str() {
+    if req.model == info.model_id.as_str() {
         // Allow user to specify the base model, but treat it as an empty adapter_id
         tracing::info!("Replacing base model {0} with empty adapter_id", req.model);
         req.model = "".to_string();
@@ -955,8 +955,6 @@ pub async fn run(
         shard_info.window_size,
         generation_health,
     );
-
-    let model_id = model_info.model_id.clone();
 
     // Duration buckets
     let duration_matcher = Matcher::Suffix(String::from("duration"));

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -786,7 +786,7 @@ async fn metrics(prom_handle: Extension<PrometheusHandle>) -> String {
 
 async fn request_logger(mut rx: mpsc::Receiver<(i64, String, String)>) {
     let url = std::env::var("REQUEST_LOGGER_URL").ok();
-    if Some(&url) == None {
+    if url.is_none() {
         tracing::info!("REQUEST_LOGGER_URL not set, request logging is disabled");
         return;
     }
@@ -1016,7 +1016,7 @@ pub async fn run(
     let (tx, rx) = mpsc::channel(32);
     let request_logger_sender = Arc::new(tx);
     let url = std::env::var("REQUEST_LOGGER_URL").ok();
-    if Some(&url) != None {
+    if url.is_some() {
         tokio::spawn(request_logger(rx));
     } else {
         tracing::info!("REQUEST_LOGGER_URL not set, request logging is disabled");

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -995,7 +995,6 @@ pub async fn run(
 
     // Kick off thread here that writes to the log file
     let (tx, rx) = mpsc::channel(32);
-    tracing::info!("!!!! ABOUT TO SPAWN THE REQUEST LOGGER THREAD <<<<<<<<<<<<");
     tokio::spawn(request_logger(rx));
     let request_logger_sender = Arc::new(tx);
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -782,11 +782,17 @@ async fn metrics(prom_handle: Extension<PrometheusHandle>) -> String {
 }
 
 async fn request_logger(mut rx: mpsc::Receiver<(i64, String, String)>) {
-    let mut file = tokio::fs::File::create("log.txt").await.unwrap();
+    // log the function is getting called
+    tracing::info!("!!!! Request logger thread is started <<<<<<<<<<<<");
+    let mut file = tokio::fs::File::create("/data/log.txt").await.unwrap();
     while let Some((tokens, metadata, gpu_type)) = rx.recv().await {
         let msg = format!(
             "Tokens: {}, Metadata: {}, GPU Type: {}\n",
             tokens, metadata, gpu_type
+        );
+        tracing::warn!(
+            "!!!! Request logger function is getting called with message: {}",
+            msg
         );
         if let Err(e) = file.write_all(msg.as_bytes()).await {
             eprintln!("Error writing to file: {}", e);


### PR DESCRIPTION
This logs some request metadata to file when a streaming request ends. This allows us to better monitor usage and has some predibase uses. 

TODO: 
- [x] Make file location an ENV VAR 
- [ ] 