### PR TITLE
Fix tensor parallelism with SGMV to use true rank of the LoRA after splitting

### DIFF
--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -263,11 +263,9 @@ class Model(ABC):
 
         if lora_a_list:
             # update rank if it was padded
-            print("PADDED RANK", lora_a_list[0].shape, lora_b_list[0].shape)
             padded_rank = lora_a_list[0].size(1)
             adapter_config.r = padded_rank
 
-        print("ADAPTER CONFIG", adapter_config.r)
         q_lora_merged = MergedLoraWeights(
             *self.shard_lora_weights(lora_a_list, lora_b_list, layer_type), adapter_config,
         )

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -261,11 +261,13 @@ class Model(ABC):
         lora_a_list = [pad_rank(w, dim=1, world_size=self.world_size) for w in lora_a_list]
         lora_b_list = [pad_rank(w, dim=0, world_size=self.world_size) for w in lora_b_list]
 
-        if lora_b_list:
+        if lora_a_list:
             # update rank if it was padded
-            padded_rank = lora_b_list[0].size(0)
+            print("PADDED RANK", lora_a_list[0].shape, lora_b_list[0].shape)
+            padded_rank = lora_a_list[0].size(1)
             adapter_config.r = padded_rank
 
+        print("ADAPTER CONFIG", adapter_config.r)
         q_lora_merged = MergedLoraWeights(
             *self.shard_lora_weights(lora_a_list, lora_b_list, layer_type), adapter_config,
         )

--- a/server/lorax_server/server.py
+++ b/server/lorax_server/server.py
@@ -128,8 +128,6 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
         )
         
     async def DownloadAdapter(self, request: generate_pb2.DownloadAdapterRequest, context):
-        import time
-        t0 = time.time()
         adapter_parameters = request.adapter_parameters
         if is_base_model(adapter_parameters):
             logger.info("No adapter to download for base model. Skipping.")
@@ -194,15 +192,12 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
                         f"(no reservation limit)")
             adapter_memory_fraction = 0.0
         
-        print("!!! DownloadAdapter took", time.time() - t0, "seconds")
         return generate_pb2.DownloadAdapterResponse(
             downloaded=True,
             memory_fraction=adapter_memory_fraction
         )
 
     async def LoadAdapter(self, request: generate_pb2.LoadAdapterRequest, context):
-        import time
-        t0 = time.time()
         adapter_parameters = request.adapter_parameters
         if is_base_model(adapter_parameters):
             logger.info("No adapter to load for base model. Skipping.")
@@ -222,7 +217,6 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
             
             self.model.load_adapter(adapter_parameters, adapter_source, adapter_index, api_token)
             
-            print("!!! LoadAdapter took", time.time() - t0, "seconds")
             return generate_pb2.LoadAdapterResponse(loaded=True)
         except Exception:
             logger.exception("Error when loading adapter")

--- a/server/lorax_server/server.py
+++ b/server/lorax_server/server.py
@@ -128,6 +128,8 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
         )
         
     async def DownloadAdapter(self, request: generate_pb2.DownloadAdapterRequest, context):
+        import time
+        t0 = time.time()
         adapter_parameters = request.adapter_parameters
         if is_base_model(adapter_parameters):
             logger.info("No adapter to download for base model. Skipping.")
@@ -192,12 +194,15 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
                         f"(no reservation limit)")
             adapter_memory_fraction = 0.0
         
+        print("!!! DownloadAdapter took", time.time() - t0, "seconds")
         return generate_pb2.DownloadAdapterResponse(
             downloaded=True,
             memory_fraction=adapter_memory_fraction
         )
 
     async def LoadAdapter(self, request: generate_pb2.LoadAdapterRequest, context):
+        import time
+        t0 = time.time()
         adapter_parameters = request.adapter_parameters
         if is_base_model(adapter_parameters):
             logger.info("No adapter to load for base model. Skipping.")
@@ -217,6 +222,7 @@ class LoraxService(generate_pb2_grpc.LoraxServiceServicer):
             
             self.model.load_adapter(adapter_parameters, adapter_source, adapter_index, api_token)
             
+            print("!!! LoadAdapter took", time.time() - t0, "seconds")
             return generate_pb2.LoadAdapterResponse(loaded=True)
         except Exception:
             logger.exception("Error when loading adapter")

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -520,8 +520,6 @@ class TensorParallelAdapterLinear(nn.Module):
         data = adapter_data.data.get(layer_type)
 
         if has_sgmv() and data is not None and data.can_vectorize(self.process_group):
-            if self.process_group.rank() == 0 and self.layer_id == 0:
-                print("!!! USE SGMV")
             if end_idx - start_idx != result.shape[1]:
                 proj = torch.zeros_like(result[:, start_idx:end_idx])
             else:
@@ -540,15 +538,10 @@ class TensorParallelAdapterLinear(nn.Module):
                         self.layer_id,
                         r,
                     )
-                    if self.process_group.rank() == 0 and self.layer_id == 0:
-                        print("V", v.shape, v.norm().item())
 
                     if self.process_group.size() > 1:
                         v = self.collect_lora_a(v)
                     
-                    if self.process_group.rank() == 0 and self.layer_id == 0:
-                        print("V collect", v.shape, v.norm().item())
-
                     lora_b_sgmv_cutlass(
                         proj,
                         v,
@@ -558,9 +551,6 @@ class TensorParallelAdapterLinear(nn.Module):
                         rank_segments.segment_ends,
                         self.layer_id,
                     )
-
-                    if self.process_group.rank() == 0 and self.layer_id == 0:
-                        print("proj", proj.shape, proj.norm().item())
             
             if end_idx - start_idx != result.shape[1]:
                 result[:, start_idx:end_idx] += proj
@@ -585,25 +575,11 @@ class TensorParallelAdapterLinear(nn.Module):
 
         lora_a = orient_for_rank(lora_a, lora_b.size(0))
 
-        if self.process_group.rank() == 0 and self.layer_id == 0:
-            print("lora_a", lora_a.shape, lora_a.norm().item())
-            print("lora_b", lora_b.shape, lora_b.norm().item())
-
         a_out = input @ lora_a
-        if self.process_group.rank() == 0 and self.layer_id == 0:
-            print("V", a_out.shape, a_out.norm().item())
-
         if self.process_group.size() > 1:
             a_out = self.collect_lora_a(a_out)
         
-        if self.process_group.rank() == 0 and self.layer_id == 0:
-            print("V collect", a_out.shape, a_out.norm().item())
-        
         result = (a_out @ lora_b) * adapter_mask
-
-        if self.process_group.rank() == 0 and self.layer_id == 0:
-            print("proj", result.shape, result.norm().item())
-
         return result
 
     def collect_lora_a(self, a_out: torch.Tensor) -> torch.Tensor:

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -54,9 +54,18 @@ class AdapterWeightData:
 
 @dataclass
 class AdapterBatchMetadata:
+    # [batch_size]
     adapter_indices: torch.Tensor
+
+    # [num_adapters]
     adapter_set: Set[int]
+
+    # [num_segments + 1]
     adapter_segments: torch.Tensor
+
+    # [num_segments]
+    # maps from segment index to adapter index, i.e.:
+    # segment_indices[s] == adapter_indices[i]
     segment_indices: List[int]
 
 

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -98,6 +98,9 @@ class MergedLoraWeights:
         weights_b: List[torch.Tensor],
         adapter_config: LoraConfig,
     ):
+        self.lora_a_r = weights_a[0].size(1) if len(weights_a) > 0 else 1
+        self.lora_b_r = weights_b[0].size(0) if len(weights_a) > 0 else 1
+
         # [num_layers, hidden_size, r]
         weights_a = [
             orient_for_rank(w, w.size(1)).contiguous()
@@ -187,8 +190,7 @@ class BatchedLoraWeights:
         for segment_idx, adapter_idx in enumerate(segment_indices):
             if adapter_idx not in self.lora_weights:
                 continue
-            print("rank indices for segment", self.lora_weights[adapter_idx].weights_b.shape)
-            rank_indices[self.lora_weights[adapter_idx].weights_b.size(1)].append(segment_idx)
+            rank_indices[self.lora_weights[adapter_idx].lora_a_r].append(segment_idx)
 
         rank_data = {}
         for rank, indices in rank_indices.items():

--- a/server/lorax_server/utils/lora.py
+++ b/server/lorax_server/utils/lora.py
@@ -46,7 +46,6 @@ class AdapterWeightData:
         return adapter_index in self.adapter_index_configs
     
     def can_vectorize(self, pg: ProcessGroup) -> bool:
-        # print("Checking if we can vectorize", [(rank_data.rank, pg.size()) for rank_data in self.rank_data.values()])
         return all(
             rank_data.rank // pg.size() <= MAX_RANK_CUSTOM
             for rank_data in self.rank_data.values()
@@ -68,7 +67,6 @@ class AdapterBatchData:
 
     @staticmethod
     def from_meta(meta: AdapterBatchMetadata, weights: Dict[str, "BatchedLoraWeights"]) -> "AdapterBatchData":
-        print("!!! FROM META")
         data = {}
         for k, v in weights.items():
             if v.is_empty():
@@ -111,7 +109,6 @@ class MergedLoraWeights:
         # [num_layers, r, hidden_size]
         self.weights_b = torch.stack(weights_b)
 
-        print("MERGED SHAPE", self.weights_a.shape, self.weights_a.shape)
         self.adapter_config = adapter_config
 
 
@@ -195,7 +192,6 @@ class BatchedLoraWeights:
         rank_data = {}
         for rank, indices in rank_indices.items():
             lora_a_ptr_indices = lora_a_ptr[indices]
-            print("Rank", rank, "Indices", lora_a_ptr_indices.shape)
             tmp_shrink, tmp_expand = get_tmp_tensors(
                 lora_a_ptr_indices.size(0),
                 rank,

--- a/server/tests/utils/test_lora.py
+++ b/server/tests/utils/test_lora.py
@@ -13,7 +13,6 @@ from lorax_server.utils.sgmv import MIN_RANK_CUSTOM
     [8, 16],
     [32, 64],
 ])
-@mock.patch("lorax_server.utils.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0)))
 def test_batched_lora_weights(lora_ranks: List[int]):
     # batch meta is hardcoded with this assumption below
     assert len(lora_ranks) == 2
@@ -42,7 +41,9 @@ def test_batched_lora_weights(lora_ranks: List[int]):
         adapter_segments=torch.tensor([0, 2, 4, 6, 8], dtype=torch.int64),
         segment_indices=[0, 1, 0, 1],
     )
-    data = batched_weights.get_data(meta)
+
+    with mock.patch("lorax_server.utils.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0))):
+        data = batched_weights.get_data(meta)
 
     assert len(data.lora_a) == 2
     assert data.lora_a.keys() == meta.adapter_set

--- a/server/tests/utils/test_lora.py
+++ b/server/tests/utils/test_lora.py
@@ -1,4 +1,5 @@
 from typing import List
+from unittest import mock
 import pytest
 
 import torch
@@ -8,6 +9,7 @@ from lorax_server.utils.lora import AdapterBatchMetadata, BatchedLoraWeights, Me
 from lorax_server.utils.sgmv import MIN_RANK_CUSTOM
 
 
+@mock.patch("lorax_server.utils.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0)))
 @pytest.mark.parametrize("lora_ranks", [
     [8, 16],
     [32, 64],

--- a/server/tests/utils/test_lora.py
+++ b/server/tests/utils/test_lora.py
@@ -1,0 +1,66 @@
+from typing import List
+import pytest
+
+import torch
+from peft import LoraConfig
+
+from lorax_server.utils.lora import AdapterBatchMetadata, BatchedLoraWeights, MergedLoraWeights
+from lorax_server.utils.sgmv import MIN_RANK_CUSTOM
+
+
+@pytest.mark.parametrize("lora_ranks", [
+    [8, 16],
+    [32, 64],
+])
+def test_batched_lora_weights(lora_ranks: List[int]):
+    # batch meta is hardcoded with this assumption below
+    assert len(lora_ranks) == 2
+
+    batched_weights = BatchedLoraWeights()
+    assert batched_weights.is_empty()
+    
+    h = 1024
+    for idx, lora_rank in enumerate(lora_ranks):
+        weights = MergedLoraWeights(
+            weights_a=[torch.randn((h, lora_rank), dtype=torch.float16)],
+            weights_b=[torch.randn((lora_rank, h), dtype=torch.float16)],
+            adapter_config=LoraConfig(r=lora_rank),
+        )
+        assert weights.lora_a_r == lora_rank
+        assert weights.lora_b_r == lora_rank
+        
+        batched_weights.add_adapter(idx, weights)
+    
+    assert not batched_weights.is_empty()
+    assert len(batched_weights.lora_weights) == 2
+
+    meta = AdapterBatchMetadata(
+        adapter_indices=torch.tensor([0, 0, 1, 1, 0, 0, 1, 1], dtype=torch.int64),
+        adapter_set={0, 1},
+        adapter_segments=torch.tensor([0, 2, 4, 6, 8], dtype=torch.int64),
+        segment_indices=[0, 1, 0, 1],
+    )
+    data = batched_weights.get_data(meta)
+
+    assert len(data.lora_a) == 2
+    assert data.lora_a.keys() == meta.adapter_set
+    assert data.lora_a[0].shape == ((1, h, lora_ranks[0]) if lora_ranks[0] < MIN_RANK_CUSTOM else (1, lora_ranks[0], h))
+    assert data.lora_a[1].shape == ((1, h, lora_ranks[1]) if lora_ranks[1] < MIN_RANK_CUSTOM else (1, lora_ranks[1], h))
+    
+    assert len(data.lora_b) == 2
+    assert data.lora_b.keys() == meta.adapter_set
+    assert data.lora_b[0].shape == (1, lora_ranks[0], h)
+    assert data.lora_b[1].shape == (1, lora_ranks[1], h)
+
+    assert len(data.rank_data) == 2
+    assert data.rank_data.keys() == set(lora_ranks)
+    for lora_rank, rd in data.rank_data.items():
+        assert rd.rank == lora_rank
+
+        # shape in all cases is the number of segments with this rank
+        assert rd.lora_a_ptr.shape == (2,)
+        assert rd.lora_b_ptr.shape == (2,)
+        assert rd.segment_starts.shape == (2,)
+        assert rd.segment_ends.shape == (2,)
+
+    print(data)

--- a/server/tests/utils/test_lora.py
+++ b/server/tests/utils/test_lora.py
@@ -9,11 +9,11 @@ from lorax_server.utils.lora import AdapterBatchMetadata, BatchedLoraWeights, Me
 from lorax_server.utils.sgmv import MIN_RANK_CUSTOM
 
 
-@mock.patch("lorax_server.utils.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0)))
 @pytest.mark.parametrize("lora_ranks", [
     [8, 16],
     [32, 64],
 ])
+@mock.patch("lorax_server.utils.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0)))
 def test_batched_lora_weights(lora_ranks: List[int]):
     # batch meta is hardcoded with this assumption below
     assert len(lora_ranks) == 2


### PR DESCRIPTION
Fixes #308.

Previous implementation assumed the rank set in the config was correct and we only need to scale by process group size. However, this may not always be the case depending on how the weights get split for tensor parallelism (column vs row parallel). As such, we should ignore the config and instead rely on the true rank dimension of the tensor independent of the process group size.