### PR TITLE
Fix hanging caused by tqdm stderr not being printed

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -497,6 +497,9 @@ fn shard_manager(
     // Safetensors load fast
     envs.push(("SAFETENSORS_FAST_GPU".into(), "1".into()));
 
+    // Disable progress bars to prevent hanging in containers
+    envs.push(("HF_HUB_DISABLE_PROGRESS_BARS".into(), "1".into()));
+
     // Enable hf transfer for insane download speeds
     let enable_hf_transfer = env::var("HF_HUB_ENABLE_HF_TRANSFER").unwrap_or("1".to_string());
     envs.push((
@@ -815,6 +818,9 @@ fn download_convert_model(
     if let Some(ref huggingface_hub_cache) = args.huggingface_hub_cache {
         envs.push(("HUGGINGFACE_HUB_CACHE".into(), huggingface_hub_cache.into()));
     };
+
+    // Disable progress bars to prevent hanging in containers
+    envs.push(("HF_HUB_DISABLE_PROGRESS_BARS".into(), "1".into()));
 
     // Enable hf transfer for insane download speeds
     let enable_hf_transfer = env::var("HF_HUB_ENABLE_HF_TRANSFER").unwrap_or("1".to_string());

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -583,15 +583,6 @@ fn shard_manager(
         }
     });
 
-    // // Redirect STDOUT to the console
-    // let shard_stdout_reader = BufReader::new(p.stdout.take().unwrap());
-    // let shard_stderr_reader = BufReader::new(p.stderr.take().unwrap());
-
-    // //stdout tracing thread
-    // thread::spawn(move || {
-    //     log_lines(shard_stdout_reader.lines());
-    // });
-
     let mut ready = false;
     let start_time = Instant::now();
     let mut wait_time = Instant::now();
@@ -602,17 +593,6 @@ fn shard_manager(
             while let Ok(line) = err_receiver.recv_timeout(Duration::from_millis(10)) {
                 err = err + "\n" + &line;
             }
-            // // We read stderr in another thread as it seems that lines() can block in some cases
-            // let (err_sender, err_receiver) = mpsc::channel();
-            // thread::spawn(move || {
-            //     for line in shard_stderr_reader.lines().flatten() {
-            //         err_sender.send(line).unwrap_or(());
-            //     }
-            // });
-            // let mut err = String::new();
-            // while let Ok(line) = err_receiver.recv_timeout(Duration::from_millis(10)) {
-            //     err = err + "\n" + &line;
-            // }
 
             tracing::error!("Shard complete standard error output:\n{err}");
 

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -785,8 +785,9 @@ class FlashCausalLM(Model):
 
             with warmup_mode():
                 with tqdm(total=max_new_tokens, desc="Warmup to max_total_tokens") as pbar:
-                    for _ in range(max_new_tokens):
+                    for i in range(max_new_tokens):
                         _, batch = self.generate_token(batch, is_warmup=True)
+                        logger.info("Warmed up to token {}", i)
                         pbar.update(1)
         except RuntimeError as e:
             if "CUDA out of memory" in str(e) or isinstance(e, torch.cuda.OutOfMemoryError):

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -784,11 +784,12 @@ class FlashCausalLM(Model):
             )
 
             with warmup_mode():
+                logger.info("Warming up to max_total_tokens: {}", max_new_tokens)
                 with tqdm(total=max_new_tokens, desc="Warmup to max_total_tokens") as pbar:
-                    for i in range(max_new_tokens):
+                    for _ in range(max_new_tokens):
                         _, batch = self.generate_token(batch, is_warmup=True)
-                        logger.info("Warmed up to token {}", i)
                         pbar.update(1)
+                logger.info("Finished generating warmup tokens")
         except RuntimeError as e:
             if "CUDA out of memory" in str(e) or isinstance(e, torch.cuda.OutOfMemoryError):
                 raise RuntimeError(


### PR DESCRIPTION
Fixes #334 
Fixes #316

Using the `lorax-launcher` in container environments like Docker / k8s, the tqdm messages are never printed to stderr. This leads to logging backpressure that eventually causes the process to hang:

https://docs.docker.com/config/containers/logging/configure/#configure-the-delivery-mode-of-log-messages-from-container-to-log-driver6

The solution here is to consume stderr in the launcher on a separate thread to avoid the backpressure from accumulating.