### PR TITLE
Fix CUDA compile when using long sequence lengths

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
@@ -217,7 +217,7 @@ class MistralAttention(torch.nn.Module):
     ):
         super().__init__()
         self.max_past = (
-            config.sliding_window if config.sliding_window is not None else 0
+            config.sliding_window if config.sliding_window is not None else -1
         )
         self.num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
@@ -538,8 +538,7 @@ class FlashMistralForCausalLM(torch.nn.Module):
         ), 0, LM_HEAD, process_group=weights.process_group)
 
         self.max_past = config.sliding_window
-        if self.max_past is None:
-            raise ValueError("max_past cannot be None")
+
 
     def forward(
         self,
@@ -558,7 +557,7 @@ class FlashMistralForCausalLM(torch.nn.Module):
         if prefill_cache_indices is not None:
             # Slots also need to be sliced as it has the same size as the whole kv tensor
             slots = slots[prefill_cache_indices]
-        else:
+        elif self.max_past is not None:
             # Clamp in decode mode as paged attention requires clamped values whereas the flash attention
             # kernel requires the true values
             max_s = min(self.max_past, max_s)

--- a/server/lorax_server/models/custom_modeling/flash_qwen2_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_qwen2_modeling.py
@@ -155,7 +155,7 @@ class FlashQwen2Attention(torch.nn.Module):
         super().__init__()
 
         self.max_past = (
-            config.sliding_window if config.sliding_window is not None else 0
+            config.sliding_window if config.sliding_window is not None else -1
         )
 
         self.num_heads = config.num_attention_heads
@@ -457,8 +457,6 @@ class FlashQwen2ForCausalLM(torch.nn.Module):
         ), 0, LM_HEAD, process_group=weights.process_group)
 
         self.max_past = config.sliding_window
-        if self.max_past is None:
-            raise ValueError("max_past cannot be None")
 
     def forward(
         self,
@@ -477,7 +475,7 @@ class FlashQwen2ForCausalLM(torch.nn.Module):
         if prefill_cache_indices is not None:
             # Slots also need to be sliced as it has the same size as the whole kv tensor
             slots = slots[prefill_cache_indices]
-        else:
+        elif self.max_past is not None:
             # Clamp in decode mode as paged attention requires clamped values whereas the flash attention
             # kernel requires the true values
             max_s = min(self.max_past, max_s)

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -912,9 +912,6 @@ class FlashCausalLM(Model):
         prefill_logprobs = batch.prefill_next_token_indices is not None
         return_alternatives = any(req.parameters.return_k_alternatives > 0 for req in batch.requests)
 
-        # Debugging for LoRAX
-        # print("!!! adapter_indices", batch.adapter_indices)
-
         if batch.needed_blocks_slots:
             # Allocate blocks to this batch
             block_tables, block_tables_tensor, slots = get_cache_manager().allocate(

--- a/server/lorax_server/models/flash_mistral.py
+++ b/server/lorax_server/models/flash_mistral.py
@@ -58,9 +58,6 @@ class FlashMistral(FlashCausalLM):
         )
         config.quantize = quantize
 
-        if config.sliding_window is None:
-            config.sliding_window = config.max_position_embeddings
-
         torch.distributed.barrier(group=self.process_group)
 
         filenames = weight_files(model_id, revision=revision, extension=".safetensors")

--- a/server/lorax_server/models/flash_qwen2.py
+++ b/server/lorax_server/models/flash_qwen2.py
@@ -99,8 +99,6 @@ class FlashQwen2(FlashCausalLM):
 
         model = FlashQwen2ForCausalLM(config, weights)
 
-        if config.sliding_window is None:
-            config.sliding_window = config.max_position_embeddings
         self.config = config
 
         torch.distributed.barrier(group=self.process_group)

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -72,6 +72,10 @@ class Model(ABC):
             device_type=self.device.type,
             window_size=self.sliding_window,
         )
+    
+    @property
+    def sliding_window_blocks(self) -> Optional[int]:
+        return None
 
     @property
     @abstractmethod

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -154,11 +154,11 @@ class Model(ABC):
         adapter_index: int,
         api_token: str,
     ):
-        """Physically loads the adapter weights into the model.
+        """Loads adapter weights from disk / host memory on the GPU.
 
         adapter_id must be `BASE_MODEL_ADAPTER_ID` if adapter statically loaded 
-        into model. Otherwise, the adapter weights are merged into the model 
-        weights on the fly.
+        into model. Otherwise, the adapter weights are applied during the forward
+        pass and stored separately from the base model parameters.
         """
         if adapter_index in self.loaded_adapters:
             # Adapter already loaded

--- a/server/lorax_server/utils/graph.py
+++ b/server/lorax_server/utils/graph.py
@@ -20,7 +20,6 @@ from lorax_server.utils.sgmv import get_tmp_expand_size, get_tmp_tensors, use_cu
 
 if TYPE_CHECKING:
     from lorax_server.models.flash_causal_lm import FlashCausalLMBatch
-    from lorax_server.models.model import Model
 
 
 # TODO(travis): make this configurable by model / user
@@ -144,7 +143,7 @@ class GraphWrapper:
         memory_pool: Tuple[int, int],
         input_state: GraphState,
         output_states: torch.Tensor,
-        model: "Model",
+        model: nn.Module,
     ):
         self.graph = graph
         self.memory_pool = memory_pool
@@ -154,7 +153,7 @@ class GraphWrapper:
         
     @staticmethod
     def trace(
-        model: "Model",
+        model: nn.Module,
         device: torch.device,
         adapter_layers: Tuple[str],
         batch_size: int,


### PR DESCRIPTION
Fixes #361.

For CUDA graph mode, we had a fixed max sequence length of 8192, this led to a mismatch between the block table size assumed by the CUDA graph manager and the model itself, which could be larger. This PR changes the behavior so the max sequence length in CUDA mode is tied to the max sequence length of the model itself.