### PR TITLE
Add CNAME file for Docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+loraexchange.ai


### PR DESCRIPTION
Adds a CNAME file in the `docs` directory so that MKDocs includes the file in the `gh-pages` branch when building the docs. This allows us to serve the docs at our custom domain loraexchange.ai. See the GitHub pages and MKDocs for more details:

- https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain
- https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains