### PR TITLE
Implement Seed Parameter Support for OpenAI-Compatible API Endpoints

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -495,6 +495,7 @@ struct ChatCompletionRequest {
     frequency_penalty: Option<f32>,
     logit_bias: Option<std::collections::HashMap<String, f32>>,
     user: Option<String>,
+    seed: Option<u64>,
     // Additional parameters
     // TODO(travis): add other LoRAX params here
     response_format: Option<ResponseFormat>,
@@ -522,6 +523,7 @@ struct CompletionRequest {
     best_of: Option<i32>,
     logit_bias: Option<std::collections::HashMap<String, f32>>,
     user: Option<String>,
+    seed: Option<u64>,
     // Additional parameters
     // TODO(travis): add other LoRAX params here
     repetition_penalty: Option<f32>,
@@ -653,7 +655,7 @@ impl From<CompletionRequest> for CompatGenerateRequest {
                 decoder_input_details: req.logprobs.is_some(),
                 return_k_alternatives: None,
                 apply_chat_template: false,
-                seed: None,
+                seed: req.seed,
                 response_format: None,
             },
             stream: req.stream.unwrap_or(false),
@@ -687,7 +689,7 @@ impl From<ChatCompletionRequest> for CompatGenerateRequest {
                 decoder_input_details: false,
                 return_k_alternatives: None,
                 apply_chat_template: true,
-                seed: None,
+                seed: req.seed,
                 response_format: req.response_format,
             },
             stream: req.stream.unwrap_or(false),


### PR DESCRIPTION

## What does this PR do?
This PR introduces the capability to specify a seed for deterministic generation in the OpenAI-compatible API endpoints (`/v1/chat/completion`, etc.) of the LoRAX local LLM serving platform. This feature aligns LoRAX more closely with the official OpenAI API, which supports deterministic outputs by allowing a seed to be specified in requests.

**Technical Details:**
- The PR adds a `seed` parameter to the `CompletionRequest` and `ChatCompletionRequest` structures.
- It ensures that this seed is passed through to the `CompatGenerateRequest` during request processing, influencing the generation process to produce deterministic outputs.
- Relevant documentation has been updated to reflect this new capability and guide users on how to utilize it.

**Dependencies:**
- There are no new dependencies introduced by this change.

Fixes #373 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue or the discord / slack channel? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?


## Who can review?
@tgaddair
cc. @soeque1