### PR TITLE
fix: Suppress pydantic warning over model_id field in DeployedModel

### DIFF
--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -336,3 +336,6 @@ class StreamResponse(BaseModel):
 class DeployedModel(BaseModel):
     model_id: str
     sha: str
+
+    # Suppress pydantic warning over `model_id` field.
+    model_config = ConfigDict(protected_namespaces=())


### PR DESCRIPTION
Otherwise you get

```
UserWarning: Field "model_id" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(

```