### PR TITLE
Support both medusa v1 and v2

### DIFF
--- a/server/lorax_server/adapters/medusa.py
+++ b/server/lorax_server/adapters/medusa.py
@@ -61,10 +61,14 @@ class ResBlock(torch.nn.Module):
     def __init__(self, config: MedusaConfig, prefix: str, weights: AbstractWeights):
         super().__init__()
         self.linear = FastLinear.load(config, prefix=f"{prefix}.linear", weights=weights, bias=True)
+        # self.lora_A = FastLinear.load(config, prefix=f"{prefix}.lora_A", weights=weights, bias=False)
+        # self.lora_B = FastLinear.load(config, prefix=f"{prefix}.lora_B", weights=weights, bias=False)
         self.act = torch.nn.SiLU()
+        self.scaling = 1
 
     def forward(self, x):
         return x + self.act(self.linear(x))
+        # return x + self.act(self.lora_B(self.lora_A(x)) * self.scaling)
 
 
 class MedusaHead(torch.nn.Module):

--- a/server/lorax_server/adapters/medusa.py
+++ b/server/lorax_server/adapters/medusa.py
@@ -19,6 +19,10 @@ class MedusaConfig(AdapterConfig):
     medusa_num_heads: int
     medusa_num_layers: int
 
+    @property
+    def quantize(self) -> Optional[str]:
+        return None
+
     def map_weights_for_model(
         self,
         adapter_weights: Dict,

--- a/server/lorax_server/adapters/medusa.py
+++ b/server/lorax_server/adapters/medusa.py
@@ -2,11 +2,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 import torch
+import torch.distributed
 
 from lorax_server.adapters.config import AdapterConfig, ModuleMap
 from lorax_server.adapters.types import MEDUSA
 from lorax_server.adapters.weights import AdapterBatchMetadata, AdapterWeights, BatchAdapterWeights
-from lorax_server.utils.layers import FastLinear
+from lorax_server.utils.layers import FastLinear, TensorParallelColumnLinear
 from lorax_server.utils.weights import AbstractWeights, InMemoryWeights
 
 if TYPE_CHECKING:
@@ -77,32 +78,81 @@ class MedusaHead(torch.nn.Module):
         self.blocks = torch.nn.ModuleList(
             [ResBlock(config, prefix=f"{prefix}.{i}", weights=weights) for i in range(config.medusa_num_layers)]
         )
-        n = len(self.blocks)
-        self.out = FastLinear.load(config, prefix=f"{prefix}.{n}", weights=weights, bias=False)
+        # n = len(self.blocks)
+        # self.out = FastLinear.load(config, prefix=f"{prefix}.{n}", weights=weights, bias=False)
 
     def forward(self, x):
         for block in self.blocks:
             x = block(x)
-        x = self.out(x)
+        # x = self.out(x)
         return x
 
 
 class MedusaModel(torch.nn.Module):
     def __init__(self, config: MedusaConfig, weights: AbstractWeights):
         super().__init__()
-        self.heads = torch.nn.ModuleList(
-            [MedusaHead(config, prefix=f"{i}", weights=weights) for i in range(config.medusa_num_heads)]
-        )
+        self.n_medusa_heads = config.medusa_num_heads
 
-    def forward(self, x):
-        speculative_logits = torch.stack([head(x) for head in self.heads], dim=1)
-        return speculative_logits
+        assert config.medusa_num_layers == 1
+        self.linear = TensorParallelColumnLinear.load_multi(
+            config,
+            prefixes=[f"{i}.0.linear" for i in range(self.n_medusa_heads)],
+            dim=0,
+            weights=weights,
+            bias=True,
+        )
+        self.process_group = weights.process_group
+        self.world_size = self.process_group.size()
+        self.rank = self.process_group.rank()
+
+        self.act = torch.nn.SiLU()
+
+    # def forward(self, x):
+    #     speculative_logits = torch.stack([head(x) for head in self.heads], dim=1)
+    #     return speculative_logits
+
+    def forward(self, x, lm_head):
+        # If we have too many tokens, we skip speculative logits
+        if x.shape[0] > 128:
+            logits = lm_head(x)
+            return logits, None
+
+        size = x.shape[-1]
+        block_size = (size + self.world_size - 1) // self.world_size
+        start = self.rank * block_size
+        stop = (self.rank + 1) * block_size
+
+        x_block = x[:, start:stop]
+
+        # Compute all medusa heads at the same time, then reshape and move the n_medusa_heads dim to dim 1
+        medusa_res = self.act(self.linear(x)).reshape(*x_block.shape[:-1], self.n_medusa_heads, x_block.shape[-1])
+
+        # Apply all residual medusa heads
+        output = x[:, start:stop].unsqueeze(-2) + medusa_res
+
+        # Gather medusa heads
+        world_output = [torch.empty_like(output) for _ in range(self.process_group.size())]
+        torch.distributed.all_gather(world_output, output, group=self.process_group)
+        world_output = torch.cat(world_output, dim=-1)
+
+        # Stack x and medusa residual x
+        stacked_x = torch.cat([x.unsqueeze(-2), world_output], dim=-2)
+
+        # Compute lm head on x + medusa residual x
+        logits = lm_head(stacked_x)
+
+        # Finally, split logits from speculative logits
+        logits, speculative_logits = torch.split(logits, [1, self.n_medusa_heads], dim=-2)
+        # Squeeze added dimension
+        logits = logits.squeeze(-2)
+
+        return logits, speculative_logits
 
 
 class MedusaWeights(AdapterWeights):
     def __init__(self, config: MedusaConfig, module_map: ModuleMap, model: "Model"):
         self.config = config
-        self.model = MedusaModel(config, InMemoryWeights(module_map, model.device, model.dtype))
+        self.model = MedusaModel(config, InMemoryWeights(module_map, model.device, model.dtype, model.process_group))
 
     @classmethod
     def get_batch_type(cls) -> BatchAdapterWeights:

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -687,7 +687,7 @@ class MultiAdapterHead(TensorParallelAdapterRowLinear):
 
         speculative_logits = None
         if data is not None and data.default_medusa is not None:
-            speculative_logits = data.default_medusa.model(input)
+            speculative_logits = data.default_medusa.model(input, self)
             # print("shape before", speculative_logits.shape)
             # speculative_logits = super().forward(speculative_logits, adapter_data)
             # print("shape after", speculative_logits.shape)

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -679,7 +679,7 @@ class MultiAdapterHead(TensorParallelAdapterRowLinear):
     def forward(
         self, input: torch.Tensor, adapter_data: "AdapterBatchData"
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-        result = super().forward(input, adapter_data)
+        # result = super().forward(input, adapter_data)
 
         # Medusa
         data = adapter_data.data.get(self.layer_name)
@@ -687,7 +687,9 @@ class MultiAdapterHead(TensorParallelAdapterRowLinear):
 
         speculative_logits = None
         if data is not None and data.default_medusa is not None:
-            speculative_logits = data.default_medusa.model(input, self)
+            forward = super().forward
+            lm_head = lambda x: forward(x, adapter_data)
+            result, speculative_logits = data.default_medusa.model(input, lm_head)
             # print("shape before", speculative_logits.shape)
             # speculative_logits = super().forward(speculative_logits, adapter_data)
             # print("shape after", speculative_logits.shape)

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -700,6 +700,8 @@ class MultiAdapterHead(TensorParallelAdapterRowLinear):
             #         adapter_mask = (adapter_data.meta.adapter_indices == adapter_index).to(input.dtype).view(-1, 1)
             #         speculative_logits = data.adapter_to_medusa[adapter_index].model(input)
             #         ...
+        else:
+            result = super().forward(input, adapter_data)
 
         return result, speculative_logits
 

--- a/server/lorax_server/utils/layers.py
+++ b/server/lorax_server/utils/layers.py
@@ -229,7 +229,9 @@ class Linear8bitLt(nn.Module):
         index=None,
     ):
         super().__init__()
-        assert not memory_efficient_backward, "memory_efficient_backward is no longer required and the argument is deprecated in 0.37.0 and will be removed in 0.39.0"
+        assert (
+            not memory_efficient_backward
+        ), "memory_efficient_backward is no longer required and the argument is deprecated in 0.37.0 and will be removed in 0.39.0"
         self.state = bnb.MatmulLtState()
         self.index = index
 
@@ -686,6 +688,9 @@ class MultiAdapterHead(TensorParallelAdapterRowLinear):
         speculative_logits = None
         if data is not None and data.default_medusa is not None:
             speculative_logits = data.default_medusa.model(input)
+            # print("shape before", speculative_logits.shape)
+            # speculative_logits = super().forward(speculative_logits, adapter_data)
+            # print("shape after", speculative_logits.shape)
 
             # TODO(travis): support multiple medusa adapters with masking:
             # for adapter_index in adapter_data.meta.adapter_set:

--- a/server/lorax_server/utils/weights.py
+++ b/server/lorax_server/utils/weights.py
@@ -14,6 +14,10 @@ from safetensors import safe_open
 
 class AbstractWeights(ABC):
     @abstractmethod
+    def get_slice(self, tensor_name: str) -> torch.Tensor:
+        pass
+
+    @abstractmethod
     def get_tensor(self, tensor_name: str) -> torch.Tensor:
         pass
 
@@ -25,140 +29,6 @@ class AbstractWeights(ABC):
     @abstractmethod
     def process_group(self):
         pass
-
-
-class InMemoryWeights(AbstractWeights):
-    def __init__(
-        self,
-        weights: Dict[str, torch.Tensor],
-        device: torch.device,
-        dtype: torch.dtype,
-        process_group: torch.distributed.ProcessGroup,
-    ):
-        self.weights = weights
-        self.device = device
-        self.dtype = dtype
-        self._process_group = process_group
-
-    def get_tensor(self, tensor_name: str) -> torch.Tensor:
-        tensor = self.weights[tensor_name]
-        tensor = tensor.to(dtype=self.dtype)
-        tensor = tensor.to(device=self.device)
-        return tensor
-
-    def get_shape(self, tensor_name: str) -> torch.Size:
-        return self.weights[tensor_name].shape
-
-    @property
-    def process_group(self):
-        return self._process_group
-
-
-class Weights(AbstractWeights):
-    """
-    A class representing weights for a model.
-
-    Args:
-        filenames (List[Path]): List of file paths containing the weights.
-        device: The device to load the weights onto.
-        dtype: The data type to convert the weights to.
-        process_group: The process group for distributed training.
-        aliases (Optional[Dict[str, List[str]]]): Dictionary of aliases for weight names.
-        merged_weight_filenames (Optional[List]): List of file paths containing merged weights.
-
-    Attributes:
-        aliases (Dict[str, List[str]]): Dictionary of aliases for weight names.
-        routing (Dict[str, str]): Dictionary mapping weight names to file paths.
-        device: The device to load the weights onto.
-        dtype: The data type of the weights.
-        process_group: The process group for distributed training.
-        _handles (Dict[str, Any]): Dictionary of file handles for opened weight files.
-    """
-
-    def __init__(
-        self,
-        filenames: List[Path],
-        device,
-        dtype,
-        process_group,
-        aliases: Optional[Dict[str, List[str]]] = None,
-        merged_weight_filenames: Optional[List] = None,
-    ):
-        # routes to adapter files take precedence over routes to main model files
-        # to ensure that adapter weights are loaded instead of main model weights
-        routing = {}
-        if merged_weight_filenames is not None:
-            for filename in merged_weight_filenames:
-                with safe_open(filename, framework="pytorch") as f:
-                    for k in f.keys():
-                        if k in routing:
-                            raise RuntimeError(
-                                f"Key {k} was found in multiple adapter files: {filename} and {routing[k]}"
-                            )
-                        routing[k] = filename
-
-        # set of keys that point to adapter files. Duplicates for these keys found
-        # in main model files will be overridden.
-        adapter_routes = set(routing.keys())
-
-        for filename in filenames:
-            with safe_open(filename, framework="pytorch") as f:
-                for k in f.keys():
-                    if k in adapter_routes:
-                        logger.debug(f"Overriding main model weights with adapter weights for key: {k}")
-                    elif k in routing:
-                        raise RuntimeError(
-                            f"Key {k} was found in multiple non-adapter files: {filename} and {routing[k]}"
-                        )
-                    else:
-                        routing[k] = filename
-
-        if aliases is None:
-            aliases = {}
-        self.aliases = aliases
-        self.routing = routing
-        self.device = device
-        self.dtype = dtype
-        self.process_group = process_group
-        self._handles = {}
-
-    def _get_handle(self, filename):
-        if filename not in self._handles:
-            f = safe_open(filename, framework="pytorch")
-            self._handles[filename] = f
-
-        return self._handles[filename]
-
-    def get_filename(self, tensor_name: str) -> (str, str):
-        filename = self.routing.get(tensor_name, None)
-        if filename is None:
-            aliases = self.aliases.get(tensor_name, [])
-            for alias in aliases:
-                filename = self.routing.get(alias, None)
-                if filename is not None:
-                    return str(filename), alias
-            raise RuntimeError(f"weight {tensor_name} does not exist")
-        return str(filename), tensor_name
-
-    def _get_slice(self, tensor_name: str):
-        filename, tensor_name = self.get_filename(tensor_name)
-        f = self._get_handle(filename)
-        slice_ = f.get_slice(tensor_name)
-        return slice_
-
-    def get_shape(self, tensor_name: str):
-        return self._get_slice(tensor_name).get_shape()
-
-    def get_tensor(self, tensor_name: str):
-        filename, tensor_name = self.get_filename(tensor_name)
-        f = self._get_handle(filename)
-        tensor = f.get_tensor(tensor_name)
-        # Special case for gptq which shouldn't convert
-        # u4 which are disguised as int32
-        if tensor.dtype not in [torch.int32, torch.int64]:
-            tensor = tensor.to(dtype=self.dtype)
-        tensor = tensor.to(device=self.device)
-        return tensor
 
     def get_partial_sharded(self, tensor_name: str, dim: int, range: Optional[Tuple[int, int]] = None):
         """Loads tensor with the given name and shards it along the given dimension.
@@ -173,17 +43,15 @@ class Weights(AbstractWeights):
             dim (int): Dimension to shard along.
             range (Optional[Tuple[int, int]]): Range of indices to load and shard as (offset, size).
         """
-        filename, tensor_name = self.get_filename(tensor_name)
         world_size = self.process_group.size()
         rank = self.process_group.rank()
 
-        f = self._get_handle(filename)
-        slice_ = f.get_slice(tensor_name)
+        slice_ = self.get_slice(tensor_name)
         if range is not None:
             offset, size = range
         else:
             offset = 0
-            size = slice_.get_shape()[dim]
+            size = slice_.shape[dim]
         start, stop = get_start_stop_idxs_for_rank(offset, size, rank, world_size)
 
         if dim == 0:
@@ -200,11 +68,9 @@ class Weights(AbstractWeights):
         return tensor
 
     def get_sharded(self, tensor_name: str, dim: int, range: Optional[Tuple[int, int]] = None):
-        filename, tensor_name = self.get_filename(tensor_name)
-        f = self._get_handle(filename)
-        slice_ = f.get_slice(tensor_name)
+        slice_ = self.get_slice(tensor_name)
         world_size = self.process_group.size()
-        size = slice_.get_shape()[dim] if range is None else range[1]
+        size = slice_.shape[dim] if range is None else range[1]
         assert size % world_size == 0, f"The choosen size {size} is not compatible with sharding on {world_size} shards"
         return self.get_partial_sharded(tensor_name, dim, range=range)
 
@@ -347,6 +213,147 @@ class Weights(AbstractWeights):
                     raise e
 
         return bits, groupsize
+
+
+class InMemoryWeights(AbstractWeights):
+    def __init__(
+        self,
+        weights: Dict[str, torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype,
+        process_group: torch.distributed.ProcessGroup,
+    ):
+        self.weights = weights
+        self.device = device
+        self.dtype = dtype
+        self._process_group = process_group
+
+    def get_slice(self, tensor_name: str) -> torch.Tensor:
+        return self.get_tensor(tensor_name)
+
+    def get_tensor(self, tensor_name: str) -> torch.Tensor:
+        tensor = self.weights[tensor_name]
+        tensor = tensor.to(dtype=self.dtype)
+        tensor = tensor.to(device=self.device)
+        return tensor
+
+    def get_shape(self, tensor_name: str) -> torch.Size:
+        return self.weights[tensor_name].shape
+
+    @property
+    def process_group(self):
+        return self._process_group
+
+
+class Weights(AbstractWeights):
+    """
+    A class representing weights for a model.
+
+    Args:
+        filenames (List[Path]): List of file paths containing the weights.
+        device: The device to load the weights onto.
+        dtype: The data type to convert the weights to.
+        process_group: The process group for distributed training.
+        aliases (Optional[Dict[str, List[str]]]): Dictionary of aliases for weight names.
+        merged_weight_filenames (Optional[List]): List of file paths containing merged weights.
+
+    Attributes:
+        aliases (Dict[str, List[str]]): Dictionary of aliases for weight names.
+        routing (Dict[str, str]): Dictionary mapping weight names to file paths.
+        device: The device to load the weights onto.
+        dtype: The data type of the weights.
+        process_group: The process group for distributed training.
+        _handles (Dict[str, Any]): Dictionary of file handles for opened weight files.
+    """
+
+    def __init__(
+        self,
+        filenames: List[Path],
+        device,
+        dtype,
+        process_group,
+        aliases: Optional[Dict[str, List[str]]] = None,
+        merged_weight_filenames: Optional[List] = None,
+    ):
+        # routes to adapter files take precedence over routes to main model files
+        # to ensure that adapter weights are loaded instead of main model weights
+        routing = {}
+        if merged_weight_filenames is not None:
+            for filename in merged_weight_filenames:
+                with safe_open(filename, framework="pytorch") as f:
+                    for k in f.keys():
+                        if k in routing:
+                            raise RuntimeError(
+                                f"Key {k} was found in multiple adapter files: {filename} and {routing[k]}"
+                            )
+                        routing[k] = filename
+
+        # set of keys that point to adapter files. Duplicates for these keys found
+        # in main model files will be overridden.
+        adapter_routes = set(routing.keys())
+
+        for filename in filenames:
+            with safe_open(filename, framework="pytorch") as f:
+                for k in f.keys():
+                    if k in adapter_routes:
+                        logger.debug(f"Overriding main model weights with adapter weights for key: {k}")
+                    elif k in routing:
+                        raise RuntimeError(
+                            f"Key {k} was found in multiple non-adapter files: {filename} and {routing[k]}"
+                        )
+                    else:
+                        routing[k] = filename
+
+        if aliases is None:
+            aliases = {}
+        self.aliases = aliases
+        self.routing = routing
+        self.device = device
+        self.dtype = dtype
+        self._process_group = process_group
+        self._handles = {}
+
+    @property
+    def process_group(self):
+        return self._process_group
+
+    def _get_handle(self, filename):
+        if filename not in self._handles:
+            f = safe_open(filename, framework="pytorch")
+            self._handles[filename] = f
+
+        return self._handles[filename]
+
+    def get_filename(self, tensor_name: str) -> (str, str):
+        filename = self.routing.get(tensor_name, None)
+        if filename is None:
+            aliases = self.aliases.get(tensor_name, [])
+            for alias in aliases:
+                filename = self.routing.get(alias, None)
+                if filename is not None:
+                    return str(filename), alias
+            raise RuntimeError(f"weight {tensor_name} does not exist")
+        return str(filename), tensor_name
+
+    def get_slice(self, tensor_name: str):
+        filename, tensor_name = self.get_filename(tensor_name)
+        f = self._get_handle(filename)
+        slice_ = f.get_slice(tensor_name)
+        return slice_
+
+    def get_shape(self, tensor_name: str):
+        return self.get_slice(tensor_name).shape
+
+    def get_tensor(self, tensor_name: str):
+        filename, tensor_name = self.get_filename(tensor_name)
+        f = self._get_handle(filename)
+        tensor = f.get_tensor(tensor_name)
+        # Special case for gptq which shouldn't convert
+        # u4 which are disguised as int32
+        if tensor.dtype not in [torch.int32, torch.int64]:
+            tensor = tensor.to(dtype=self.dtype)
+        tensor = tensor.to(device=self.device)
+        return tensor
 
     def _set_config(self, model_id, config):
         self.config = config

--- a/server/lorax_server/utils/weights.py
+++ b/server/lorax_server/utils/weights.py
@@ -21,12 +21,24 @@ class AbstractWeights(ABC):
     def get_shape(self, tensor_name: str) -> torch.Size:
         pass
 
+    @property
+    @abstractmethod
+    def process_group(self):
+        pass
+
 
 class InMemoryWeights(AbstractWeights):
-    def __init__(self, weights: Dict[str, torch.Tensor], device: torch.device, dtype: torch.dtype):
+    def __init__(
+        self,
+        weights: Dict[str, torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype,
+        process_group: torch.distributed.ProcessGroup,
+    ):
         self.weights = weights
         self.device = device
         self.dtype = dtype
+        self._process_group = process_group
 
     def get_tensor(self, tensor_name: str) -> torch.Tensor:
         tensor = self.weights[tensor_name]
@@ -36,6 +48,10 @@ class InMemoryWeights(AbstractWeights):
 
     def get_shape(self, tensor_name: str) -> torch.Size:
         return self.weights[tensor_name].shape
+
+    @property
+    def process_group(self):
+        return self._process_group
 
 
 class Weights(AbstractWeights):


### PR DESCRIPTION
TGI recently introduced a smaller version of Medusa that doesn't require additional LM heads (only a single dense projection per "medusa head"). This makes it a great candidate for dynamic adapter loading, as new variants for 7b param models are < 100MB.

This implementation is taken largely from the one in TGI.