### PR TITLE
fix: use logits to calculate alternative tokens

### DIFF
--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -980,7 +980,7 @@ class FlashCausalLM(Model):
 
         if return_alternatives:
             alternative_token_logprobs, alternative_token_ids = torch.sort(
-                torch.log_softmax(next_token_logprobs, -1), dim=-1, stable=True, descending=True
+                torch.log_softmax(next_token_logits, -1), dim=-1, stable=True, descending=True
             )
 
         if prefill:


### PR DESCRIPTION
Since #372, trying to return alternative tokens with any request will crash the server at https://github.com/predibase/lorax/blob/2017d451eb05d1429d1530a329b0c8a79a82e90c/server/lorax_server/models/flash_causal_lm.py#L1144-L1147, as `next_token_logprobs` is a scalar when returned from the `NextTokenChooser` invocation. This PR reverts the calculation of alternative tokens back to use the `next_token_logits`, which still holds the calculated logits for all possible tokens in the vocabulary.
