### PR TITLE
use default HF HUB token when checking for base model info

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,154 +1,154 @@
 name: Build and push docker image to ghcr
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - "main"
-            - "fix-adapter-not-loading"
-        tags:
-            - "v*"
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
 
 jobs:
-    build-and-push-image:
-        concurrency:
-            group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
-            cancel-in-progress: true
-        runs-on: a100-runner
-        permissions:
-            contents: write
-            packages: write
-            # This is used to complete the identity challenge
-            # with sigstore/fulcio when running outside of PRs.
-            id-token: write
-            security-events: write
+  build-and-push-image:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    runs-on: a100-runner
+    permissions:
+      contents: write
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+      security-events: write
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-              with:
-                  submodules: recursive
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
-            - name: Free Disk Space (Ubuntu)
-              uses: jlumbroso/free-disk-space@main
-              with:
-                  tool-cache: false
-                  android: true
-                  dotnet: true
-                  haskell: true
-                  large-packages: false
-                  swap-storage: true
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
 
-            - name: Install soci
-              uses: lerentis/soci-installer@v1.0.1
-              with:
-                  soci-release: "v0.4.0"
+      - name: Install soci
+        uses: lerentis/soci-installer@v1.0.1
+        with:
+          soci-release: 'v0.4.0'
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.10.0
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v2.10.0
+      - name: Set up containerd for ubuntu
+        uses: crazy-max/ghaction-setup-containerd@v2.2.0
+        with:
+          config-inline: |
+            version = 2
+            
+            # persistent data location
+            root = "/runner/build/containerd"
 
-            - name: Set up containerd for ubuntu
-              uses: crazy-max/ghaction-setup-containerd@v2.2.0
-              with:
-                  config-inline: |
-                      version = 2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/predibase/lorax
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+      
+      - name: Create a hash from tags
+        env:
+          tags: ${{ steps.meta.outputs.tags }}
+        id: vars
+        run: |
+          tag_hash=$(echo -n "$tags" | md5sum | awk '{print $1}')
+          echo "tag_hash=$tag_hash" >> $GITHUB_OUTPUT
+          echo "cache_dir=/runner/build/images/cache" >> $GITHUB_OUTPUT
+          echo "image_dir=/runner/build/images" >> $GITHUB_OUTPUT
+          echo "image_path=/runner/build/images/lorax" >> $GITHUB_OUTPUT
 
-                      # persistent data location
-                      root = "/runner/build/containerd"
+      - name: Create and update image/cache directory
+        env:
+          image_dir: ${{ steps.vars.outputs.image_dir }}
+          cache_dir: ${{ steps.vars.outputs.cache_dir }}
+        run: |
+          sudo mkdir -p $image_dir
+          sudo chown ubuntu:ubuntu $image_dir
 
-            - name: Docker meta
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: |
-                      ghcr.io/predibase/lorax
-                  tags: |
-                      type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
-                      type=sha,prefix=,suffix=,format=short
-                      type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+          sudo mkdir -p $cache_dir
+          sudo chown ubuntu:ubuntu $cache_dir
 
-            - name: Create a hash from tags
-              env:
-                  tags: ${{ steps.meta.outputs.tags }}
-              id: vars
-              run: |
-                  tag_hash=$(echo -n "$tags" | md5sum | awk '{print $1}')
-                  echo "tag_hash=$tag_hash" >> $GITHUB_OUTPUT
-                  echo "cache_dir=/runner/build/images/cache" >> $GITHUB_OUTPUT
-                  echo "image_dir=/runner/build/images" >> $GITHUB_OUTPUT
-                  echo "image_path=/runner/build/images/lorax" >> $GITHUB_OUTPUT
+      - name: Export Docker image as OCI
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile  # Path to your Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=oci,compression=gzip,dest=${{ steps.vars.outputs.image_path }}-${{ steps.vars.outputs.tag_hash }}.tar.gz
+          cache-from: type=local,src=${{ steps.vars.outputs.cache_dir }}
+          cache-to: type=local,mode=max,image-manifest=true,oci-mediatypes=true,dest=${{ steps.vars.outputs.cache_dir }}
 
-            - name: Create and update image/cache directory
-              env:
-                  image_dir: ${{ steps.vars.outputs.image_dir }}
-                  cache_dir: ${{ steps.vars.outputs.cache_dir }}
-              run: |
-                  sudo mkdir -p $image_dir
-                  sudo chown ubuntu:ubuntu $image_dir
+      - name: Import image in containerd
+        env:
+          tag_hash: ${{ steps.vars.outputs.tag_hash }}
+          image_path: ${{ steps.vars.outputs.image_path }}
+        run: |
+          echo "Importing $image_path-$tag_hash to Containerd"
+          sudo ctr i import --no-unpack --all-platforms --digests $image_path-$tag_hash.tar.gz
 
-                  sudo mkdir -p $cache_dir
-                  sudo chown ubuntu:ubuntu $cache_dir
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
 
-            - name: Export Docker image as OCI
-              uses: docker/build-push-action@v5
-              with:
-                  context: .
-                  file: ./Dockerfile # Path to your Dockerfile
-                  push: false
-                  tags: ${{ steps.meta.outputs.tags }}
-                  outputs: type=oci,compression=gzip,dest=${{ steps.vars.outputs.image_path }}-${{ steps.vars.outputs.tag_hash }}.tar.gz
-                  cache-from: type=local,src=${{ steps.vars.outputs.cache_dir }}
-                  cache-to: type=local,mode=max,image-manifest=true,oci-mediatypes=true,dest=${{ steps.vars.outputs.cache_dir }}
+      - name: Push image with containerd
+        env:
+          tags: ${{ steps.meta.outputs.tags }}
+        run: |
+          for tag in $tags
+          do
+            echo "Pushing $tag to GHCR"
+            sudo ctr i push --user "${{ github.repository_owner }}:${{ secrets.GHCR_PAT }}" $tag
+          done
+      
+      - name: Create and push soci index
+        env:
+          tags: ${{ steps.meta.outputs.tags }}
+        run: |
+          export SOCI_PATH=$HOME/.soci/soci
+          for tag in $tags
+          do
+            echo "Creating soci index for $tag"
+            sudo $SOCI_PATH create $tag
+            echo "Pushing soci index for $tag"
+            sudo $SOCI_PATH push --user ${{ github.repository_owner }}:${{ secrets.GHCR_PAT }} $tag
+          done
 
-            - name: Import image in containerd
-              env:
-                  tag_hash: ${{ steps.vars.outputs.tag_hash }}
-                  image_path: ${{ steps.vars.outputs.image_path }}
-              run: |
-                  echo "Importing $image_path-$tag_hash to Containerd"
-                  sudo ctr i import --no-unpack --all-platforms --digests $image_path-$tag_hash.tar.gz
+      - name: Prune older images
+        env:
+          tag_hash: ${{ steps.vars.outputs.tag_hash }}
+          image_path: ${{ steps.vars.outputs.image_path }}
+        run: |
+          # Delete images older than a day from docker store
+          docker image prune -a -f --filter "until=24h"
 
-            - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v1
-              with:
-                  registry: ghcr.io
-                  username: ${{ github.repository_owner }}
-                  password: ${{ secrets.GHCR_PAT }}
+          # Delete the on disk copy
+          rm -rf "$image_path-$tag_hash.tar.gz"
 
-            - name: Push image with containerd
-              env:
-                  tags: ${{ steps.meta.outputs.tags }}
-              run: |
-                  for tag in $tags
-                  do
-                    echo "Pushing $tag to GHCR"
-                    sudo ctr i push --user "${{ github.repository_owner }}:${{ secrets.GHCR_PAT }}" $tag
-                  done
-
-            - name: Create and push soci index
-              env:
-                  tags: ${{ steps.meta.outputs.tags }}
-              run: |
-                  export SOCI_PATH=$HOME/.soci/soci
-                  for tag in $tags
-                  do
-                    echo "Creating soci index for $tag"
-                    sudo $SOCI_PATH create $tag
-                    echo "Pushing soci index for $tag"
-                    sudo $SOCI_PATH push --user ${{ github.repository_owner }}:${{ secrets.GHCR_PAT }} $tag
-                  done
-
-            - name: Prune older images
-              env:
-                  tag_hash: ${{ steps.vars.outputs.tag_hash }}
-                  image_path: ${{ steps.vars.outputs.image_path }}
-              run: |
-                  # Delete images older than a day from docker store
-                  docker image prune -a -f --filter "until=24h"
-
-                  # Delete the on disk copy
-                  rm -rf "$image_path-$tag_hash.tar.gz"
-
-                  # Delete the SHA image(s) from containerd store
-                  sudo ctr i rm $(sudo ctr i ls -q)
+          # Delete the SHA image(s) from containerd store
+          sudo ctr i rm $(sudo ctr i ls -q)
+  

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,154 +1,154 @@
 name: Build and push docker image to ghcr
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'main'
-    tags:
-      - 'v*'
+    workflow_dispatch:
+    push:
+        branches:
+            - "main"
+            - "fix-adapter-not-loading"
+        tags:
+            - "v*"
 
 jobs:
-  build-and-push-image:
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
-    runs-on: a100-runner
-    permissions:
-      contents: write
-      packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
-      security-events: write
+    build-and-push-image:
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.run_id }}
+            cancel-in-progress: true
+        runs-on: a100-runner
+        permissions:
+            contents: write
+            packages: write
+            # This is used to complete the identity challenge
+            # with sigstore/fulcio when running outside of PRs.
+            id-token: write
+            security-events: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+              with:
+                  submodules: recursive
 
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: true
+            - name: Free Disk Space (Ubuntu)
+              uses: jlumbroso/free-disk-space@main
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: false
+                  swap-storage: true
 
-      - name: Install soci
-        uses: lerentis/soci-installer@v1.0.1
-        with:
-          soci-release: 'v0.4.0'
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.10.0
+            - name: Install soci
+              uses: lerentis/soci-installer@v1.0.1
+              with:
+                  soci-release: "v0.4.0"
 
-      - name: Set up containerd for ubuntu
-        uses: crazy-max/ghaction-setup-containerd@v2.2.0
-        with:
-          config-inline: |
-            version = 2
-            
-            # persistent data location
-            root = "/runner/build/containerd"
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2.10.0
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/predibase/lorax
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=,suffix=,format=short
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-      
-      - name: Create a hash from tags
-        env:
-          tags: ${{ steps.meta.outputs.tags }}
-        id: vars
-        run: |
-          tag_hash=$(echo -n "$tags" | md5sum | awk '{print $1}')
-          echo "tag_hash=$tag_hash" >> $GITHUB_OUTPUT
-          echo "cache_dir=/runner/build/images/cache" >> $GITHUB_OUTPUT
-          echo "image_dir=/runner/build/images" >> $GITHUB_OUTPUT
-          echo "image_path=/runner/build/images/lorax" >> $GITHUB_OUTPUT
+            - name: Set up containerd for ubuntu
+              uses: crazy-max/ghaction-setup-containerd@v2.2.0
+              with:
+                  config-inline: |
+                      version = 2
 
-      - name: Create and update image/cache directory
-        env:
-          image_dir: ${{ steps.vars.outputs.image_dir }}
-          cache_dir: ${{ steps.vars.outputs.cache_dir }}
-        run: |
-          sudo mkdir -p $image_dir
-          sudo chown ubuntu:ubuntu $image_dir
+                      # persistent data location
+                      root = "/runner/build/containerd"
 
-          sudo mkdir -p $cache_dir
-          sudo chown ubuntu:ubuntu $cache_dir
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: |
+                      ghcr.io/predibase/lorax
+                  tags: |
+                      type=semver,pattern={{version}}
+                      type=semver,pattern={{major}}.{{minor}}
+                      type=sha,prefix=,suffix=,format=short
+                      type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - name: Export Docker image as OCI
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile  # Path to your Dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          outputs: type=oci,compression=gzip,dest=${{ steps.vars.outputs.image_path }}-${{ steps.vars.outputs.tag_hash }}.tar.gz
-          cache-from: type=local,src=${{ steps.vars.outputs.cache_dir }}
-          cache-to: type=local,mode=max,image-manifest=true,oci-mediatypes=true,dest=${{ steps.vars.outputs.cache_dir }}
+            - name: Create a hash from tags
+              env:
+                  tags: ${{ steps.meta.outputs.tags }}
+              id: vars
+              run: |
+                  tag_hash=$(echo -n "$tags" | md5sum | awk '{print $1}')
+                  echo "tag_hash=$tag_hash" >> $GITHUB_OUTPUT
+                  echo "cache_dir=/runner/build/images/cache" >> $GITHUB_OUTPUT
+                  echo "image_dir=/runner/build/images" >> $GITHUB_OUTPUT
+                  echo "image_path=/runner/build/images/lorax" >> $GITHUB_OUTPUT
 
-      - name: Import image in containerd
-        env:
-          tag_hash: ${{ steps.vars.outputs.tag_hash }}
-          image_path: ${{ steps.vars.outputs.image_path }}
-        run: |
-          echo "Importing $image_path-$tag_hash to Containerd"
-          sudo ctr i import --no-unpack --all-platforms --digests $image_path-$tag_hash.tar.gz
+            - name: Create and update image/cache directory
+              env:
+                  image_dir: ${{ steps.vars.outputs.image_dir }}
+                  cache_dir: ${{ steps.vars.outputs.cache_dir }}
+              run: |
+                  sudo mkdir -p $image_dir
+                  sudo chown ubuntu:ubuntu $image_dir
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+                  sudo mkdir -p $cache_dir
+                  sudo chown ubuntu:ubuntu $cache_dir
 
-      - name: Push image with containerd
-        env:
-          tags: ${{ steps.meta.outputs.tags }}
-        run: |
-          for tag in $tags
-          do
-            echo "Pushing $tag to GHCR"
-            sudo ctr i push --user "${{ github.repository_owner }}:${{ secrets.GHCR_PAT }}" $tag
-          done
-      
-      - name: Create and push soci index
-        env:
-          tags: ${{ steps.meta.outputs.tags }}
-        run: |
-          export SOCI_PATH=$HOME/.soci/soci
-          for tag in $tags
-          do
-            echo "Creating soci index for $tag"
-            sudo $SOCI_PATH create $tag
-            echo "Pushing soci index for $tag"
-            sudo $SOCI_PATH push --user ${{ github.repository_owner }}:${{ secrets.GHCR_PAT }} $tag
-          done
+            - name: Export Docker image as OCI
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: ./Dockerfile # Path to your Dockerfile
+                  push: false
+                  tags: ${{ steps.meta.outputs.tags }}
+                  outputs: type=oci,compression=gzip,dest=${{ steps.vars.outputs.image_path }}-${{ steps.vars.outputs.tag_hash }}.tar.gz
+                  cache-from: type=local,src=${{ steps.vars.outputs.cache_dir }}
+                  cache-to: type=local,mode=max,image-manifest=true,oci-mediatypes=true,dest=${{ steps.vars.outputs.cache_dir }}
 
-      - name: Prune older images
-        env:
-          tag_hash: ${{ steps.vars.outputs.tag_hash }}
-          image_path: ${{ steps.vars.outputs.image_path }}
-        run: |
-          # Delete images older than a day from docker store
-          docker image prune -a -f --filter "until=24h"
+            - name: Import image in containerd
+              env:
+                  tag_hash: ${{ steps.vars.outputs.tag_hash }}
+                  image_path: ${{ steps.vars.outputs.image_path }}
+              run: |
+                  echo "Importing $image_path-$tag_hash to Containerd"
+                  sudo ctr i import --no-unpack --all-platforms --digests $image_path-$tag_hash.tar.gz
 
-          # Delete the on disk copy
-          rm -rf "$image_path-$tag_hash.tar.gz"
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GHCR_PAT }}
 
-          # Delete the SHA image(s) from containerd store
-          sudo ctr i rm $(sudo ctr i ls -q)
-  
+            - name: Push image with containerd
+              env:
+                  tags: ${{ steps.meta.outputs.tags }}
+              run: |
+                  for tag in $tags
+                  do
+                    echo "Pushing $tag to GHCR"
+                    sudo ctr i push --user "${{ github.repository_owner }}:${{ secrets.GHCR_PAT }}" $tag
+                  done
+
+            - name: Create and push soci index
+              env:
+                  tags: ${{ steps.meta.outputs.tags }}
+              run: |
+                  export SOCI_PATH=$HOME/.soci/soci
+                  for tag in $tags
+                  do
+                    echo "Creating soci index for $tag"
+                    sudo $SOCI_PATH create $tag
+                    echo "Pushing soci index for $tag"
+                    sudo $SOCI_PATH push --user ${{ github.repository_owner }}:${{ secrets.GHCR_PAT }} $tag
+                  done
+
+            - name: Prune older images
+              env:
+                  tag_hash: ${{ steps.vars.outputs.tag_hash }}
+                  image_path: ${{ steps.vars.outputs.image_path }}
+              run: |
+                  # Delete images older than a day from docker store
+                  docker image prune -a -f --filter "until=24h"
+
+                  # Delete the on disk copy
+                  rm -rf "$image_path-$tag_hash.tar.gz"
+
+                  # Delete the SHA image(s) from containerd store
+                  sudo ctr i rm $(sudo ctr i ls -q)

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -86,8 +86,8 @@ def _load_and_merge(
 
 def check_architectures(model_id: str, adapter_id: str, adapter_config: "AdapterConfig", api_token: str):
     try:
-        expected_config = AutoConfig.from_pretrained(model_id, token=api_token)
-        model_config = AutoConfig.from_pretrained(adapter_config.base_model_name_or_path, token=api_token)
+        expected_config = AutoConfig.from_pretrained(model_id)
+        model_config = AutoConfig.from_pretrained(adapter_config.base_model_name_or_path)
     except Exception as e:
         warnings.warn(
             f"Unable to check architecture compatibility for adapter '{adapter_id}' "

--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -84,7 +84,7 @@ def _load_and_merge(
     return module_map, adapter_config, merged_weight_names, tokenizer
 
 
-def check_architectures(model_id: str, adapter_id: str, adapter_config: "AdapterConfig", api_token: str):
+def check_architectures(model_id: str, adapter_id: str, adapter_config: "AdapterConfig"):
     try:
         expected_config = AutoConfig.from_pretrained(model_id)
         model_config = AutoConfig.from_pretrained(adapter_config.base_model_name_or_path)
@@ -123,7 +123,7 @@ def load_module_map(
     config_path = get_config_path(adapter_id, adapter_source)
     adapter_config = source.load_config()
     if adapter_config.base_model_name_or_path != model_id:
-        check_architectures(model_id, adapter_id, adapter_config, api_token)
+        check_architectures(model_id, adapter_id, adapter_config)
 
     try:
         adapter_tokenizer = AutoTokenizer.from_pretrained(config_path, token=api_token)


### PR DESCRIPTION
- This is important now that the models are gated, we need to use the token which started the model, since that _should_ have permissions to read the base model repo! 