### PR TITLE
fix: checking the base_model_name_or_path of adapter_config and early return if null

### DIFF
--- a/server/lorax_server/utils/adapter.py
+++ b/server/lorax_server/utils/adapter.py
@@ -86,6 +86,10 @@ def _load_and_merge(
 
 def check_architectures(model_id: str, adapter_id: str, adapter_config: "AdapterConfig"):
     try:
+        if not adapter_config.base_model_name_or_path:
+            # Avoid execuation latency caused by the network connection retrying for AutoConfig.from_pretrained(None)
+            return
+
         expected_config = AutoConfig.from_pretrained(model_id)
         model_config = AutoConfig.from_pretrained(adapter_config.base_model_name_or_path)
     except Exception as e:


### PR DESCRIPTION
# What does this PR do?

Fixes #430 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue or the discord / slack channel? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?

## Who can review?

@tgaddair
