### PR TITLE
Fix special tokens showing up in the response

### DIFF
--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -42,7 +42,13 @@ class Model(ABC):
         self.model = model.eval()
         self.tokenizer = tokenizer
         self.tokenizers = TokenizerManager()
+
         self.all_special_ids = set(tokenizer.all_special_ids)
+
+        # all_special_ids is not set correctly if the rust tokenizer is unpacked
+        other_special_ids = {id for id, token in tokenizer.added_tokens_decoder.items() if token.special}
+        self.all_special_ids.update(other_special_ids)
+
         self.requires_padding = requires_padding
         self.dtype = dtype
         self.device = device


### PR DESCRIPTION
Fix upstream from TGI for special tokens (e.g., Phi3) showing up in the response.