### PR TITLE
Updated lorax-launcher docs to include HF Hub API Token

### DIFF
--- a/docs/reference/launcher.md
+++ b/docs/reference/launcher.md
@@ -12,6 +12,11 @@ Options:
           [env: MODEL_ID=]
           [default: mistralai/Mistral-7B-Instruct-v0.1]
 
+      --env <HUGGING_FACE_HUB_TOKEN>
+          Your Hugging Face API token to authenticate access to private or gated models on the Hugging Face Hub. This token can be set as an environment variable or passed directly through the command line
+
+        [env: HUGGING_FACE_HUB_TOKEN=]
+
       --adapter-id <ADAPTER_ID>
           The name of the adapter to load. Can be a MODEL_ID as listed on <https://hf.co/models> or it can be a local directory containing the necessary files as saved by `save_pretrained(...)` methods of transformers. Should be compatible with the model specified in `model_id`
           

--- a/docs/reference/launcher.md
+++ b/docs/reference/launcher.md
@@ -15,7 +15,7 @@ Options:
       --env <HUGGING_FACE_HUB_TOKEN>
           Your Hugging Face API token to authenticate access to private or gated models on the Hugging Face Hub. This token can be set as an environment variable or passed directly through the command line
 
-        [env: HUGGING_FACE_HUB_TOKEN=]
+          [env: HUGGING_FACE_HUB_TOKEN=]
 
       --adapter-id <ADAPTER_ID>
           The name of the adapter to load. Can be a MODEL_ID as listed on <https://hf.co/models> or it can be a local directory containing the necessary files as saved by `save_pretrained(...)` methods of transformers. Should be compatible with the model specified in `model_id`


### PR DESCRIPTION
# What does this PR do?

Fixes #451 Add HF authentication instructions to lorax-launcher docs

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@tgaddair 