### PR TITLE
Reuse session per class instance

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -42,6 +42,7 @@ class Client:
         headers: Optional[Dict[str, str]] = None,
         cookies: Optional[Dict[str, str]] = None,
         timeout: int = 60,
+        session: Optional[requests.Session] = None,
     ):
         """
         Args:
@@ -53,11 +54,14 @@ class Client:
                 Cookies to include in the requests
             timeout (`int`):
                 Timeout in seconds
+            session (`Optional[requests.Session]`):
+                HTTP requests session object to reuse
         """
         self.base_url = base_url
         self.headers = headers
         self.cookies = cookies
         self.timeout = timeout
+        self.session = session or requests.Session()
 
     def generate(
         self,
@@ -178,7 +182,7 @@ class Client:
         )
         request = Request(inputs=prompt, stream=False, parameters=parameters)
 
-        resp = requests.post(
+        resp = self.session.post(
             self.base_url,
             json=request.dict(by_alias=True),
             headers=self.headers,
@@ -309,7 +313,7 @@ class Client:
         )
         request = Request(inputs=prompt, stream=True, parameters=parameters)
 
-        resp = requests.post(
+        resp = self.session.post(
             self.base_url,
             json=request.dict(by_alias=True),
             headers=self.headers,


### PR DESCRIPTION
# What does this PR do?

The PR introduces a "session" object to reuse when making API calls to the LLM server. Instead of instantiating a new requests instance on each HTTP call, reusing the same session object allows you to reuse socket connections and improve performance.

# How was this PR tested

I ran netstat to monitor the number of open sockets/connections the library makes before and after this change.
Before this change ~40 open socket sessions were created on a normal LLM call which would expire about every 30 seconds, after this change it makes 1 socket session that gets renewed/refreshed every time there is call to the API.

FIXES: INFRA-2744