### PR TITLE
Fix for the LM_HEAD issue

### DIFF
--- a/server/lorax_server/adapters/lora.py
+++ b/server/lorax_server/adapters/lora.py
@@ -162,6 +162,7 @@ class LoraWeights(AdapterWeights):
 @dataclass
 class RankSegments:
     rank: int
+    indices: List[int]
     tmp_shrink: torch.Tensor
     tmp_expand: torch.Tensor
     lora_a_ptr: torch.Tensor
@@ -231,6 +232,7 @@ class BatchLoraWeights(BatchAdapterWeights):
 
             rank_data[rank] = RankSegments(
                 rank=rank,
+                indices=indices,
                 tmp_shrink=tmp_shrink,
                 tmp_expand=tmp_expand,
                 lora_a_ptr=lora_a_ptr_indices,

--- a/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
@@ -29,6 +29,8 @@ from transformers.activations import ACT2FN
 from transformers.configuration_utils import PretrainedConfig
 
 from lorax_server.adapters import AdapterBatchData
+from lorax_server.adapters.lora import LoraWeights
+from lorax_server.adapters.types import LORA
 from lorax_server.utils import flash_attn, paged_attn
 from lorax_server.utils.flash_attn import HAS_FLASH_ATTN_V2
 from lorax_server.utils.layers import (
@@ -588,5 +590,30 @@ class FlashMistralForCausalLM(torch.nn.Module):
         )
         if lm_head_indices is not None:
             hidden_states = hidden_states[lm_head_indices]
+            update_segments_for_lm_head(adapter_data, lm_head_indices)
         logits, speculative_logits = self.lm_head(hidden_states, adapter_data)
         return logits, speculative_logits
+
+
+# only call if all conditions below are true
+# 1. lm_head_indices is not None
+# 2. len(adapter_data.meta.adapter_set) > 0
+# 3. LM_HEAD in adapter_data.data
+# 4. LORA in adapter_data.data[LM_HEAD]
+def update_segments_for_lm_head(adapter_data: AdapterBatchData, lm_head_indices: torch.Tensor) -> None:
+    if len(adapter_data.meta.adapter_set) and LM_HEAD in adapter_data.data and LORA in adapter_data.data[LM_HEAD]:
+        j, segment_inds = 1, adapter_data.meta.adapter_segments
+        starts, ends = [0], [0]
+        for lm_head_index in lm_head_indices:
+            # j cannot go out of bounds as that would mean there are tokens without corresponding adapters
+            if lm_head_index < segment_inds[j]:
+                ends[-1] += 1
+            else:
+                starts.append(ends[-1])
+                ends.append(ends[-1] + 1)
+                j += 1
+
+        for _, rank_segment in adapter_data.data[LM_HEAD][LORA].rank_data.items():
+            for i, segment_index in enumerate(rank_segment.indices):
+                rank_segment.segment_starts[i] = starts[segment_index]
+                rank_segment.segment_ends[i] = ends[segment_index]


### PR DESCRIPTION
# (WIP) Fix for the LM_HEAD issue

**Root Cause**. The error is caused by incorrect segments passed to the `lora_b_sgmv` kernel during the prefill stage. This happens because we do not want to forward all the tokens in the prompt through `lm_head` and associated adapters. The goal is to save compute and memory by not having to forward the tokens that are not involved in generating the next token. Only the last token is needed for this purpose. However, doing this changes the shape of the net batch size (batch size times number of tokens) that the lora kernel sees, but the segment start and end tensors are not changed. These tensors are used to slice/segment the batch in the kernel. Hence, keeping them unchanged is incorrect. Additionally, the resulting error from this problem not reported correctly since the kernel has a catch-call condition that reports a generic `kernel not found for the dtype` message. My guess is that it's an out-of-bounds memory access, but confirming this would require changing the kernel. This is out of the scope of this investigation.


**Description of the Fix**. The fix simply goes over the adapters for `lm_head` and adjusts the segment start and end tensors to correctly point to the segments in the batch. For now, this is done only during the prefill stage and when a LoRA adapter for the `lm_head` is present.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #163 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue or the discord / slack channel? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@tgaddair

 -->
