### PR TITLE
Bug fix for illegal memory access error caused when running medusa lora and plain loras in parallel.

### DIFF
--- a/server/lorax_server/adapters/lora.py
+++ b/server/lorax_server/adapters/lora.py
@@ -338,9 +338,9 @@ class BatchLoraWeights(BatchAdapterWeights):
                         segment_starts[i] = prefill_head_segment_starts[segment_index]
                         segment_ends[i] = prefill_head_segment_ends[segment_index]
             else:
-                rank_indices = set(indices)
+                index_locations = {idx: loc for loc, idx in enumerate(indices)}
                 batch_indices = [adapter_to_segment[idx] for idx in meta.adapter_indices.tolist()]
-                batch_indices = [idx if idx in rank_indices else -1 for idx in batch_indices]
+                batch_indices = [index_locations.get(idx, -1) for idx in batch_indices]
                 batch_indices = torch.tensor(batch_indices, dtype=torch.int64, device=device)
 
             rank_data[rank] = RankSegments(

--- a/server/tests/utils/test_lora.py
+++ b/server/tests/utils/test_lora.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Optional, Tuple, Type
 from unittest import mock
 
 import pytest
@@ -101,6 +101,69 @@ def test_batched_lora_weights(lora_ranks: List[int]):
         assert rd.segment_starts.shape == (2,)
         assert rd.segment_ends.shape == (2,)
 
+
+
+@pytest.mark.parametrize(
+    "lora_ranks,adapter_indices,expected",
+    [
+        (
+            [8, 8, 16],
+            [0, 0, 1, 1, 0, 0, 1, 1, 2, 2],
+            {
+                8: (4, [0, 0, 1, 1, 0, 0, 1, 1, -1, -1]),
+                16: (1, [-1, -1, -1, -1, -1, -1, -1, -1, 0, 0])
+            }
+        ),
+        (
+            [4, 8, 16],
+            [0, 0, 1, 1, 0, 0, 1, 1, 2, 2],
+            {
+                4: (2, [0, 0, -1, -1, 0, 0, -1, -1, -1, -1]),
+                8: (2, [-1, -1, 0, 0, -1, -1, 0, 0, -1, -1]),
+                16: (1, [-1, -1, -1, -1, -1, -1, -1, -1, 0, 0]),
+            }
+        ),
+    ],
+)
+def test_batched_lora_weights_decode(
+    lora_ranks: List[int],
+    adapter_indices: List[int],
+    expected: Dict[int, Tuple[int, List[int]]]
+):
+    from lorax_server.utils.segments import find_segments
+    batched_weights = LayerAdapterWeights()
+    assert batched_weights.is_empty()
+
+    h = 1024
+    for idx, lora_rank in enumerate(lora_ranks):
+        weights = LoraWeights(
+            weights_a=[torch.randn((h, lora_rank), dtype=torch.float16)],
+            weights_b=[torch.randn((lora_rank, h), dtype=torch.float16)],
+            adapter_config=LoraConfig(r=lora_rank),
+        )
+        batched_weights.add_adapter(idx, weights)
+
+    segments, segment_indices = find_segments(adapter_indices)
+
+    meta = AdapterBatchMetadata(
+        adapter_indices=torch.tensor(adapter_indices, dtype=torch.int64),
+        adapter_set=set(adapter_indices),
+        adapter_segments=torch.tensor(segments, dtype=torch.int64),
+        segment_indices=segment_indices,
+    )
+
+    with mock.patch("lorax_server.adapters.lora.get_tmp_tensors", return_value=(torch.empty(0), torch.empty(0))):
+        data = batched_weights.get_data(meta, prefill=False, prefill_head_indices=None).get(LORA)
+
+    for lora_rank, rd in data.rank_data.items():
+        expected_indices = torch.tensor(expected[lora_rank][1], dtype=rd.indices.dtype, device=rd.indices.device)
+        assert rd.lora_a_ptr.shape == (expected[lora_rank][0],)
+        assert rd.lora_b_ptr.shape == (expected[lora_rank][0],)
+        assert all(rd.indices == expected_indices)
+        assert rd.segment_starts == None
+        assert rd.segment_ends == None
+        assert rd.tmp_shrink == None
+        assert rd.tmp_expand == None
 
 def test_batched_lora_weights_no_segments():
     batched_weights = LayerAdapterWeights()


### PR DESCRIPTION
The error is caused when forwarding through the BGMV kernel during the decode stage and when there are multiple lora adapters. The reason is the discrepancy between the list of lora weight pointers and indices into them. This pull request fixes this. I used the following script to test that everything is working properly.

```
import fire
from multiprocessing import Pool
from lorax import Client
import numpy as np
import time

adapters = [
    ("/usr/src/lorax/medusa-23", "local"),
    ("vineetsharma/qlora-adapter-Mistral-7B-Instruct-v0.1-gsm8k", "hub"),
    ("predibase/magicoder", "hub"),
    ("predibase/gsm8k", "hub"),
    (None, None),
]

max_new_tokens = 30

def send_request(idx):
    adapter_id, adapter_source = adapters[idx]
    client = Client("http://127.0.0.1:8080", timeout=(60 * 100))
    prompt = "[INST] How much is 2 + 2? [/INST]"
    print(f'==> Send request: {adapter_id}::{adapter_source}')
    time.sleep(np.random.permutation(10)[0])
    if adapter_id is not None:
        result = client.generate(
            prompt,
            adapter_id=adapter_id,
            adapter_source=adapter_source,
            max_new_tokens=max_new_tokens,
        ).generated_text
    else:
        result = client.generate(prompt, max_new_tokens=max_new_tokens).generated_text
    print(f'==> Rcvd request: {adapter_id}::{adapter_source}')
    return result, adapter_id, adapter_source


def main(num_workers: int, num_requests: int, seed: int = 123):
    np.random.seed(seed)
    adapter_indices = [i % len(adapters) for i in np.random.permutation(100)][:num_requests]
    with Pool(num_workers) as p:
        for result, adapter_id, adapter_source in p.map(send_request, adapter_indices):
            print(f'============== {adapter_id} //// {adapter_source} ==============')
            print(result)
            print(f'================================================================')


if __name__ == '__main__':
    fire.Fire(main)
```

Run it with parameters `--num-workers 10 --num-requests 100 --seed 123`