### PR TITLE
bug : fix Qwen-2 sliding_window config bug

### DIFF
--- a/server/lorax_server/models/flash_qwen2.py
+++ b/server/lorax_server/models/flash_qwen2.py
@@ -69,6 +69,8 @@ class FlashQwen2(FlashCausalLM):
 
         config = Qwen2Config.from_pretrained(model_id, revision=revision, trust_remote_code=trust_remote_code)
         config.quantize = quantize
+        if not config.use_sliding_window:
+            config.sliding_window = None
 
         torch.distributed.barrier(group=self.process_group)
 


### PR DESCRIPTION
The Qwen-2 config contains a large value for `sliding_window` config but the default value for `use_sliding_window` is false. This causes the cache manager to allocate a huge kv cache despite it being not used by the model. This PR fixes this bug.