### PR TITLE
Fix : compile bug causing models to error with 'lora' key not found

### DIFF
--- a/server/lorax_server/adapters/weights.py
+++ b/server/lorax_server/adapters/weights.py
@@ -117,7 +117,9 @@ class AdapterBatchData:
         for k, v in weights.items():
             if v.is_empty():
                 continue
-            data[k] = v.get_data(meta, prefill, prefill_head_indices if k == LM_HEAD else None)
+            layer_weights = v.get_data(meta, prefill, prefill_head_indices if k == LM_HEAD else None)
+            if layer_weights:
+                data[k] = layer_weights
         return AdapterBatchData(meta=meta, data=data, prefill=prefill)
 
     def ranks(self) -> Set[int]:


### PR DESCRIPTION
The problem happens because `adapter_data.data` may contain keys (layer names) with empty dict values (layer-wise adapter weights). Empty values causes the graph module to [create input state](https://github.com/predibase/lorax/blob/5a7a1beaf9fae676b57260157738ba9ea8ae6f8b/server/lorax_server/utils/graph.py#L184) for non-existent adapter weights which causes the 'lora' key not found error. This is fixed by simply not storing empty dicts in `adapter_data.data`.
