### PR TITLE
Allow `eager_prefill` to be set in Helm chart

### DIFF
--- a/charts/lorax/templates/deployment.yaml
+++ b/charts/lorax/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --sharded
         - {{ .Values.deployment.args.sharded | quote }}
         - --eager-prefill
-        - {{ .Values.deployment.args.eager_prefill | quote }}
+        - {{ .Values.deployment.args.eagerPrefill | quote }}
         env:
         - name: PORT
           value: "8000"

--- a/charts/lorax/templates/deployment.yaml
+++ b/charts/lorax/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         - {{ .Values.deployment.args.maxBatchPrefillTokens | quote }}
         - --sharded
         - {{ .Values.deployment.args.sharded | quote }}
+        - --eager-prefill
+        - {{ .Values.deployment.args.eager_prefill | quote }}
         env:
         - name: PORT
           value: "8000"

--- a/charts/lorax/values.yaml
+++ b/charts/lorax/values.yaml
@@ -13,7 +13,7 @@ deployment:
     maxBatchTotalTokens: 4096
     maxBatchPrefillTokens: 2048
     sharded: false
-    eager_prefill: false
+    eagerPrefill: false
 
   env:
     # Your huggingface hub token. Required for some models such as the llama-2 family.

--- a/charts/lorax/values.yaml
+++ b/charts/lorax/values.yaml
@@ -13,6 +13,7 @@ deployment:
     maxBatchTotalTokens: 4096
     maxBatchPrefillTokens: 2048
     sharded: false
+    eager_prefill: false
 
   env:
     # Your huggingface hub token. Required for some models such as the llama-2 family.


### PR DESCRIPTION
# What does this PR do?
This PR adds the `eager_prefill` option to the helm chart so callers can set it while deploying Lorax. 
I found this option as I was digging through all the deploy args the service supports in [main.rs](https://github.com/predibase/lorax/blob/main/launcher/src/main.rs#L295-L299) and decided to try it as my usecase was more throughput bound. I found a ~11% improvement in throughput in my application with this option set on the docker container.
So creating this PR to add the option to the helm chart so it can be deployed to my K8s clusters.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue or the discord / slack channel? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@tgaddair @noyoshi @arnavgarg1 
Tagging all the folks I've seen made recent edits to the helm chart.