### PR TITLE
Introduce the "adapter_version" parameter for convenience in the "generate()" methods.

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -143,6 +143,7 @@ class Client:
         self,
         prompt: str,
         adapter_id: Optional[str] = None,
+        adapter_version: Optional[int] = None,
         adapter_source: Optional[str] = None,
         merged_adapters: Optional[MergedAdapters] = None,
         api_token: Optional[str] = None,
@@ -173,8 +174,13 @@ class Client:
                 Input text
             adapter_id (`Optional[str]`):
                 Adapter ID to apply to the base model for the request
+            adapter_version: (`Optional[int]`):
+                Adapter version (applicable only when `adapter_source` is "pbase").
+                The format of `adapter_id` is "<ID>[/version]".  If `adapter_version` is
+                specified, then `adapter_id` is suffixed by `/adapter_version`, so for
+                convenience, `adapter_id` and `adapter_version` can be passed in separately.
             adapter_source (`Optional[str]`):
-                Source of the adapter (hub, local, s3)
+                Source of the adapter ("hub", "local", "s3", "pbase")
             merged_adapters (`Optional[MergedAdapters]`):
                 Merged adapters to apply to the base model for the request
             api_token (`Optional[str]`):
@@ -234,6 +240,7 @@ class Client:
         # Validate parameters
         parameters = Parameters(
             adapter_id=adapter_id,
+            adapter_version=adapter_version,
             adapter_source=adapter_source,
             merged_adapters=merged_adapters,
             api_token=api_token,
@@ -282,6 +289,7 @@ class Client:
         self,
         prompt: str,
         adapter_id: Optional[str] = None,
+        adapter_version: Optional[int] = None,
         adapter_source: Optional[str] = None,
         merged_adapters: Optional[MergedAdapters] = None,
         api_token: Optional[str] = None,
@@ -309,8 +317,13 @@ class Client:
                 Input text
             adapter_id (`Optional[str]`):
                 Adapter ID to apply to the base model for the request
+            adapter_version: (`Optional[int]`):
+                Adapter version (applicable only when `adapter_source` is "pbase").
+                The format of `adapter_id` is "<ID>[/version]".  If `adapter_version` is
+                specified, then `adapter_id` is suffixed by `/adapter_version`, so for
+                convenience, `adapter_id` and `adapter_version` can be passed in separately.
             adapter_source (`Optional[str]`):
-                Source of the adapter (hub, local, s3)
+                Source of the adapter ("hub", "local", "s3", "pbase")
             merged_adapters (`Optional[MergedAdapters]`):
                 Merged adapters to apply to the base model for the request
             api_token (`Optional[str]`):
@@ -364,6 +377,7 @@ class Client:
         # Validate parameters
         parameters = Parameters(
             adapter_id=adapter_id,
+            adapter_version=adapter_version,
             adapter_source=adapter_source,
             merged_adapters=merged_adapters,
             api_token=api_token,

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -70,6 +70,8 @@ class ResponseFormat(BaseModel):
 class Parameters(BaseModel):
     # The ID of the adapter to use
     adapter_id: Optional[str] = None
+    # The version of the adapter to use (applicable only when `adapter_source` is "pbase")
+    adapter_version: Optional[int] = None,
     # The source of the adapter to use
     adapter_source: Optional[str] = None
     # Adapter merge parameters
@@ -122,7 +124,18 @@ class Parameters(BaseModel):
         merged_adapters = self.merged_adapters
         if adapter_id is not None and merged_adapters is not None:
             raise ValidationError("you must specify at most one of `adapter_id` or `merged_adapters`")
+
+        adapter_version = self.adapter_version
+        if adapter_id and adapter_version:
+            self.adapter_id = f"{adapter_id}/{adapter_version}"
+
         return self
+
+    @field_validator("adapter_version")
+    def valid_adapter_version(cls, v):
+        if not isinstance(v, int) or v < 1:
+            raise ValidationError(f"`adapter_version={v}` must be a positive integer")
+        return v
 
     @field_validator("adapter_source")
     def valid_adapter_source(cls, v):

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -133,7 +133,7 @@ class Parameters(BaseModel):
 
     @field_validator("adapter_version")
     def valid_adapter_version(cls, v):
-        if not isinstance(v, int) or v < 1:
+        if v < 1:
             raise ValidationError(f"`adapter_version={v}` must be a positive integer")
         return v
 

--- a/clients/python/tests/test_types.py
+++ b/clients/python/tests/test_types.py
@@ -78,10 +78,11 @@ def test_parameters_validation():
     Parameters(adapter_id="test-adapter-id")
     Parameters(adapter_id="test-adapter-id/1")
     Parameters(adapter_id="test-adapter-id", adapter_version=1)
+    Parameters(adapter_id="test-adapter-id", adapter_version="1")  # Passes, thanks to Pydantic auto-coercion.
     with pytest.raises(ValidationError):
         Parameters(adapter_id="test-adapter-id", adapter_version=0)
     with pytest.raises(ValidationError):
-        Parameters(adapter_id="test-adapter-id", adapter_version="1")
+        Parameters(adapter_id="test-adapter-id", adapter_version="not_an_integer")
 
 
 def test_request_validation():

--- a/clients/python/tests/test_types.py
+++ b/clients/python/tests/test_types.py
@@ -74,6 +74,15 @@ def test_parameters_validation():
     with pytest.raises(ValidationError):
         Parameters(adapter_id="test/adapter-id", merged_adapters=merged_adapters)
 
+    # Test adapter_id and adapter_version
+    Parameters(adapter_id="test-adapter-id")
+    Parameters(adapter_id="test-adapter-id/1")
+    Parameters(adapter_id="test-adapter-id", adapter_version=1)
+    with pytest.raises(ValidationError):
+        Parameters(adapter_id="test-adapter-id", adapter_version=0)
+    with pytest.raises(ValidationError):
+        Parameters(adapter_id="test-adapter-id", adapter_version="1")
+
 
 def test_request_validation():
     Request(inputs="test")

--- a/clients/python/tests/test_types.py
+++ b/clients/python/tests/test_types.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pydantic
+
 from lorax.types import Parameters, Request, MergedAdapters
 from lorax.errors import ValidationError
 
@@ -81,7 +83,7 @@ def test_parameters_validation():
     Parameters(adapter_id="test-adapter-id", adapter_version="1")  # Passes, thanks to Pydantic auto-coercion.
     with pytest.raises(ValidationError):
         Parameters(adapter_id="test-adapter-id", adapter_version=0)
-    with pytest.raises(ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         Parameters(adapter_id="test-adapter-id", adapter_version="not_an_integer")
 
 

--- a/docs/reference/python_client/client.md
+++ b/docs/reference/python_client/client.md
@@ -72,6 +72,7 @@ def __init__(base_url: str,
 def generate(prompt: str,
              adapter_id: Optional[str] = None,
              adapter_source: Optional[str] = None,
+             adapter_version: Optional[int] = None,
              merged_adapters: Optional[MergedAdapters] = None,
              api_token: Optional[str] = None,
              do_sample: bool = False,
@@ -101,8 +102,10 @@ Given a prompt, generate the following text
   Input text
   - adapter_id (`Optional[str]`):
   Adapter ID to apply to the base model for the request
+  - adapter_version: (`Optional[int]`):
+  The version of the adapter to use (applicable only when `adapter_source` is "pbase")
   - adapter_source (`Optional[str]`):
-  Source of the adapter (hub, local, s3)
+  Source of the adapter ("hub", "local", "s3", "pbase")
   - merged_adapters (`Optional[MergedAdapters]`):
   Merged adapters to apply to the base model for the request
   - api_token (`Optional[str]`):
@@ -164,6 +167,7 @@ Given a prompt, generate the following text
 ```python
 def generate_stream(prompt: str,
                     adapter_id: Optional[str] = None,
+                    adapter_version: Optional[int] = None,
                     adapter_source: Optional[str] = None,
                     merged_adapters: Optional[MergedAdapters] = None,
                     api_token: Optional[str] = None,
@@ -192,6 +196,8 @@ Given a prompt, generate the following stream of tokens
   Input text
   - adapter_id (`Optional[str]`):
   Adapter ID to apply to the base model for the request
+  - adapter_version: (`Optional[int]`):
+  The version of the adapter to use (applicable only when `adapter_source` is "pbase")
   - adapter_source (`Optional[str]`):
   Source of the adapter (hub, local, s3)
   - merged_adapters (`Optional[MergedAdapters]`):
@@ -302,6 +308,7 @@ def __init__(base_url: str,
 ```python
 async def generate(prompt: str,
                    adapter_id: Optional[str] = None,
+                   adapter_version: Optional[int] = None,
                    adapter_source: Optional[str] = None,
                    merged_adapters: Optional[MergedAdapters] = None,
                    api_token: Optional[str] = None,
@@ -332,6 +339,8 @@ Given a prompt, generate the following text asynchronously
   Input text
   - adapter_id (`Optional[str]`):
   Adapter ID to apply to the base model for the request
+  - adapter_version: (`Optional[int]`):
+  The version of the adapter to use (applicable only when `adapter_source` is "pbase")
   - adapter_source (`Optional[str]`):
   Source of the adapter (hub, local, s3)
   - merged_adapters (`Optional[MergedAdapters]`):
@@ -396,6 +405,7 @@ Given a prompt, generate the following text asynchronously
 async def generate_stream(
         prompt: str,
         adapter_id: Optional[str] = None,
+        adapter_version: Optional[int] = None,
         adapter_source: Optional[str] = None,
         merged_adapters: Optional[MergedAdapters] = None,
         api_token: Optional[str] = None,
@@ -424,6 +434,8 @@ Given a prompt, generate the following stream of tokens asynchronously
   Input text
   - adapter_id (`Optional[str]`):
   Adapter ID to apply to the base model for the request
+  - adapter_version: (`Optional[int]`):
+  The version of the adapter to use (applicable only when `adapter_source` is "pbase")
   - adapter_source (`Optional[str]`):
   Source of the adapter (hub, local, s3)
   - merged_adapters (`Optional[MergedAdapters]`):


### PR DESCRIPTION
# What does this PR do?

For user and notebook use-cases, one often works with fine-tuned adapters hosted by Predibase.  The `adapter_id` format for such adapters is: repository/version where repository (string) and version (int) are both required (with the "/" as the separator between).  However, this causes users to constantly have to put in an "if then": without the adapter, `adapter_id` can be omitted; with the adapter, then both `adapter_id` and the version are required.  In our typical notebooks, we first prompt the base model (i.e., no adapter), then we prompt the fine-tuned adapter (in order to compare their performance).  Hence, the same wrapper function is being copied and pasted from one notebook to another:
```
def lorax_generate(
    client: Client,
    prompt: str,
    adapter_id: str | None = None,
    adapter_version: int | None = None,
    **kwargs,
) -> str:
    kwargs = kwargs or {}

    if adapter_id and adapter_version:
        adapter_id = f"{adapter_id}/{adapter_version}"

    response: Response = client.generate(
        prompt=prompt,
        adapter_id=adapter_id,
        **kwargs,
    )
    generated_text: str = response.generated_text

    return generated_text
```

This is repetitive and error prone.  Incorporating the flexibility and convenience inside LoRAX solves the issue.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Was this discussed/approved via a Github issue or the discord / slack channel? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
