### PR TITLE
Support FlashInfer for BERT

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_bert_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_bert_modeling.py
@@ -58,7 +58,7 @@ class DistilBertAttention:
         qkv = torch.addmm(self.qkv_bias, hidden_states, self.qkv_weight)
         q, k, v = qkv.view(-1, self.num_heads * 3, self.head_size).split(self.num_heads, dim=1)
 
-        attn_output = attention(q, k, v, None, None, cu_seqlens, max_s, self.softmax_scale)
+        attn_output = attention(q, k, v, None, None, cu_seqlens, max_s, self.softmax_scale, causal=False)
 
         hidden_states = torch.addmm(
             self.dense_bias,
@@ -162,7 +162,7 @@ class BertAttention:
         qkv = torch.addmm(self.qkv_bias, hidden_states, self.qkv_weight)
         q, k, v = qkv.view(-1, self.num_heads * 3, self.head_size).split(self.num_heads, dim=1)
 
-        attn_output = attention(q, k, v, None, None, cu_seqlens, max_s, self.softmax_scale)
+        attn_output = attention(q, k, v, None, None, cu_seqlens, max_s, self.softmax_scale, causal=False)
 
         hidden_states = torch.addmm(
             self.dense_bias,

--- a/server/lorax_server/models/custom_modeling/siglip.py
+++ b/server/lorax_server/models/custom_modeling/siglip.py
@@ -50,7 +50,7 @@ class SiglipVisionEmbeddings(nn.Module):
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
         # TODO(travis): check why this is necessary
         pixel_values = pixel_values.to(self.patch_embedding.weight.dtype)
-        
+
         patch_embeds = self.patch_embedding(pixel_values)  # shape = [*, width, grid, grid]
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
 

--- a/server/lorax_server/models/flash_bert.py
+++ b/server/lorax_server/models/flash_bert.py
@@ -1,7 +1,6 @@
 from contextlib import nullcontext
-from typing import Any, ContextManager, List, Optional, Type
+from typing import Any, ContextManager, Optional, Type
 
-from lorax_server.utils.state import FLASH_INFER
 import torch
 from opentelemetry import trace
 from transformers import AutoTokenizer
@@ -16,6 +15,7 @@ from lorax_server.utils import (
     initialize_torch_distributed,
     weight_files,
 )
+from lorax_server.utils.state import FLASH_INFER
 
 tracer = trace.get_tracer(__name__)
 
@@ -117,6 +117,7 @@ class FlashBert(Model):
 
         if FLASH_INFER:
             from lorax_server.utils.flashinfer_attention import create_prefill_state
+
             self.prefill_state = create_prefill_state(device=device)
 
         super(FlashBert, self).__init__(
@@ -156,7 +157,7 @@ class FlashBert(Model):
         if not self.supports_text_generation:
             raise NotImplementedError("This model does not support text generation")
         return None
-    
+
     def _forward_context(
         self,
         *,

--- a/server/lorax_server/models/vlm_causal_lm.py
+++ b/server/lorax_server/models/vlm_causal_lm.py
@@ -269,7 +269,7 @@ class VlmCausalLM(FlashCausalLM):
             raise NotImplementedError("Vlm do not work with prefix caching yet")
         if processor_kwargs is None:
             processor_kwargs = {}
-        
+
         processor = processor_class.from_pretrained(
             model_id,
             revision=revision,

--- a/server/lorax_server/utils/flash_attn.py
+++ b/server/lorax_server/utils/flash_attn.py
@@ -137,6 +137,7 @@ if FLASH_INFER:
                 k,
                 v,
                 causal=causal,
+                pos_encoding_mode="NONE",
                 window_left=window_size_left,
                 logits_soft_cap=softcap,
                 sm_scale=softmax_scale,


### PR DESCRIPTION
For some BERT models it was observed that FA2 can be numerically unstable, while FlashInfer is more consistent with the results observed from vanilla transformers and PyTorch's SDPA function.