### PR TITLE
Add --predibase-api-token CLI arg

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,6 @@
 name: Build and push docker image to ghcr
 
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Build and push docker image to ghcr
 
 on:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -210,6 +210,11 @@ struct Args {
     #[clap(long, env)]
     preloaded_adapter_source: Option<String>,
 
+    /// The API token to use when fetching adapters from pbase.
+    /// If specified, will set the environment variable PREDIBASE_API_TOKEN.
+    #[clap(long, env)]
+    predibase_api_token: Option<String>,
+
     /// The dtype to be forced upon the model. This option cannot be used with `--quantize`.
     #[clap(long, env, value_enum)]
     dtype: Option<Dtype>,
@@ -461,6 +466,7 @@ fn shard_manager(
     speculative_tokens: Option<usize>,
     preloaded_adapter_ids: Vec<String>,
     preloaded_adapter_source: Option<String>,
+    predibase_api_token: Option<String>,
     dtype: Option<Dtype>,
     trust_remote_code: bool,
     uds_path: String,
@@ -492,6 +498,9 @@ fn shard_manager(
     if uds.exists() {
         fs::remove_file(uds).unwrap();
     }
+
+    // Copy current process env
+    let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
 
     // Process args
     let mut shard_args = vec![
@@ -552,6 +561,13 @@ fn shard_manager(
         shard_args.push(preloaded_adapter_source);
     }
 
+    if let Some(predibase_api_token) = predibase_api_token {
+        envs.push((
+            "PREDIBASE_API_TOKEN".into(),
+            predibase_api_token.to_string().into(),
+        ));
+    }
+
     if let Some(dtype) = dtype {
         shard_args.push("--dtype".to_string());
         shard_args.push(dtype.to_string())
@@ -568,9 +584,6 @@ fn shard_manager(
         shard_args.push("--otlp-endpoint".to_string());
         shard_args.push(otlp_endpoint);
     }
-
-    // Copy current process env
-    let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
 
     // Torch Distributed Env vars
     envs.push(("RANK".into(), rank.to_string().into()));
@@ -1030,6 +1043,7 @@ fn spawn_shards(
         let speculative_tokens = args.speculative_tokens;
         let preloaded_adapter_ids = args.preloaded_adapter_ids.clone();
         let preloaded_adapter_source = args.preloaded_adapter_source.clone();
+        let predibase_api_token = args.predibase_api_token.clone();
         let dtype = args.dtype;
         let trust_remote_code = args.trust_remote_code;
         let master_port = args.master_port;
@@ -1052,6 +1066,7 @@ fn spawn_shards(
                 speculative_tokens,
                 preloaded_adapter_ids,
                 preloaded_adapter_source,
+                predibase_api_token,
                 dtype,
                 trust_remote_code,
                 uds_path,


### PR DESCRIPTION
Adds the `--predibase-api-token` CLI arg. When set, this sets the `PREDIBASE_API_TOKEN` environment variable, which is used when fetching adapters from pbase.

Tested by deploying a lorax build with this argument, runing with the parameters `--predibase-api-token <token> --preloaded-adapter-source pbase --preloaded-adapter-ids testv2-parallel-c3ebf415/1` and verifying that it successfully loads.