### PR TITLE
Support FP8 KV Cache

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -31,6 +31,7 @@ enum Quantization {
     Hqq_3bit,
     Hqq_2bit,
     Fp8,
+    Fp8_KV,
 }
 
 impl std::fmt::Display for Quantization {
@@ -66,6 +67,9 @@ impl std::fmt::Display for Quantization {
             }
             Quantization::Fp8 => {
                 write!(f, "fp8")
+            }
+            Quantization::Fp8_KV => {
+                write!(f, "fp8_kv")
             }
         }
     }

--- a/server/lorax_server/cli.py
+++ b/server/lorax_server/cli.py
@@ -23,6 +23,7 @@ class Quantization(str, Enum):
     hqq_3bit = "hqq-3bit"
     hqq_2bit = "hqq-2bit"
     fp8 = "fp8"
+    fp8_kv = "fp8_kv"
 
 
 class Dtype(str, Enum):

--- a/server/lorax_server/layers/linear.py
+++ b/server/lorax_server/layers/linear.py
@@ -95,9 +95,9 @@ def get_linear(weight, bias, quantize, fan_in_fan_out=False, weight_scale=None, 
     if fan_in_fan_out:
         weight = weight.T.contiguous()
 
-    if quantize is None or (quantize == "fp8" and weight_scale is None):
+    if quantize is None or (quantize.startswith("fp8") and weight_scale is None):
         linear = FastLinear(weight, bias)
-    elif quantize == "fp8":
+    elif quantize.startswith("fp8"):
         from lorax_server.layers.fp8 import Fp8Linear
 
         linear = Fp8Linear(weight, bias, weight_scale=weight_scale, input_scale=input_scale)

--- a/server/lorax_server/layers/tensor_parallel.py
+++ b/server/lorax_server/layers/tensor_parallel.py
@@ -37,7 +37,7 @@ class TensorParallelHead(SuperLayer):
             should_gather = False
 
         # GPTQ,AWQ,EETQ don't quantize heads (nor embeddings)
-        if config.quantize in ["gptq", "awq", "eetq", "fp8"]:
+        if config.quantize in ["gptq", "awq", "eetq", "fp8", "fp8_kv"]:
             quantize = None
         else:
             quantize = config.quantize

--- a/server/lorax_server/models/custom_modeling/flash_llama_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_llama_modeling.py
@@ -199,7 +199,7 @@ def _load_gqa(config, prefix: str, weights):
     if isinstance(weight, tuple):
         weight, input_scale, weight_scale = weight
 
-    if config.quantize not in ["gptq", "awq", "fp8"]:
+    if config.quantize not in ["gptq", "awq", "fp8", "fp8_kv"]:
         weight = weight.to(dtype=weights.dtype).to(device=weights.device)
 
         head_size = config.hidden_size // config.num_attention_heads
@@ -251,6 +251,16 @@ class FlashLlamaAttention(torch.nn.Module):
             )
         self.num_heads = self.num_heads // weights.process_group.size()
         self.num_key_value_heads = config.num_key_value_heads // weights.process_group.size()
+        # todo(ajinkya): only supports the default 'fp8' dtype in vLLM for kv cache but
+        # we can also support other dtypes like f8_e4m3
+        if paged_attention.is_fp8_supported() and config.quantize and config.quantize.endswith('_kv'):
+            self.kv_cache_dtype = 'fp8'
+            self.k_scale = weights.get_tensor(f"{prefix}.k_scale", use_self_dtype=False)
+            self.v_scale = weights.get_tensor(f"{prefix}.v_scale", use_self_dtype=False)
+        else:
+            self.kv_cache_dtype = 'auto'
+            self.k_scale = 1.0
+            self.v_scale = 1.0
 
         self.query_key_value = load_attention(config, prefix, weights, layer_id)
 
@@ -318,7 +328,16 @@ class FlashLlamaAttention(torch.nn.Module):
         self.rotary_emb(query, cos, sin)
         self.rotary_emb(torch.select(kv, dim=1, index=0), cos, sin)
 
-        paged_attention.reshape_and_cache(kv[:, 0], kv[:, 1], kv_cache[0], kv_cache[1], slots)
+        paged_attention.reshape_and_cache(
+            kv[:, 0],
+            kv[:, 1],
+            kv_cache[0],
+            kv_cache[1],
+            slots,
+            # self.kv_cache_dtype,
+            # self.k_scale,
+            # self.v_scale,
+        )
 
         # Prefill
         if cu_seqlen_prefill is not None:
@@ -346,6 +365,9 @@ class FlashLlamaAttention(torch.nn.Module):
                 block_tables,
                 input_lengths,
                 max_s,
+                # self.kv_cache_dtype,
+                # self.k_scale,
+                # self.v_scale,
             )
 
         return self.o_proj(attn_output.view(-1, self.num_heads * self.head_size), adapter_data)

--- a/server/lorax_server/utils/torch_utils.py
+++ b/server/lorax_server/utils/torch_utils.py
@@ -13,7 +13,7 @@ def is_bf16_supported() -> bool:
 def is_fp8_quantized(config, layer_name):
     # check if quantization is fp8 and either of the fused layers is not ignored
     # typically, either all qkv will be quantized or none so just check for one
-    if config.quantize == "fp8" and hasattr(config, "quantization_config"):
+    if config.quantize and config.quantize.startswith("fp8") and hasattr(config, "quantization_config"):
         ignored_layers = set(config.quantization_config.get("ignored_layers", []))
         if layer_name not in ignored_layers:
             return "fp8"

--- a/server/lorax_server/utils/weights.py
+++ b/server/lorax_server/utils/weights.py
@@ -117,7 +117,7 @@ class AbstractWeights(ABC):
             weight = (qweight, qzeros, scales, g_idx, bits, groupsize, False)
         else:
             weight_list = self.get_sharded_list("weight", prefixes, dim=0)
-            if quantize == "fp8" and weight_list[0].dtype == torch.float8_e4m3fn:
+            if quantize and quantize.startswith("fp8") and weight_list[0].dtype == torch.float8_e4m3fn:
                 # Since there is no kernel for concatenating two tensors in PyTorch
                 # for fp8 datatypes, we have to cast to fp16, concat, cast back to fp8
                 fp16_weight_list = [w.to(torch.float16) for w in weight_list]
@@ -220,7 +220,7 @@ class AbstractWeights(ABC):
             weight = (qweight, qzeros, scales, g_idx, bits, groupsize, use_exllama)
         else:
             weight = self.get_sharded(f"{prefix}.weight", dim=1)
-            if quantize == "fp8" and weight.dtype == torch.float8_e4m3fn:
+            if quantize and quantize.startswith("fp8") and weight.dtype == torch.float8_e4m3fn:
                 # weight_scale could be a tensor but if we're sharding row-wise then no
                 # need to shard the weight_scale as its row dimension would be 1
                 weight_scale = self.get_tensor(f"{prefix}.weight_scale", use_self_dtype=False)


### PR DESCRIPTION
Prefill uses flash attention 2 kernels so attention happens in FP16, but KV tensors are quantized to FP8 before storing them in KV Cache. Uses static scales calculated using the Ultra-2k chat dataset and AutoFP8 repository. Accuracy and model speed both are low at the moment.