### PR TITLE
Fix PREDIBASE_API_TOKEN env var being thrown away

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -522,9 +522,6 @@ fn shard_manager(
         fs::remove_file(uds).unwrap();
     }
 
-    // Copy current process env
-    let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
-
     // Process args
     let mut shard_args = vec![
         "serve".to_string(),
@@ -588,13 +585,6 @@ fn shard_manager(
         shard_args.push(preloaded_adapter_source);
     }
 
-    if let Some(predibase_api_token) = predibase_api_token {
-        envs.push((
-            "PREDIBASE_API_TOKEN".into(),
-            predibase_api_token.to_string().into(),
-        ));
-    }
-
     if let Some(dtype) = dtype {
         shard_args.push("--dtype".to_string());
         shard_args.push(dtype.to_string())
@@ -620,6 +610,13 @@ fn shard_manager(
 
     // Copy current process env
     let mut envs: Vec<(OsString, OsString)> = env::vars_os().collect();
+
+    if let Some(predibase_api_token) = predibase_api_token {
+        envs.push((
+            "PREDIBASE_API_TOKEN".into(),
+            predibase_api_token.to_string().into(),
+        ));
+    }
 
     // Torch Distributed Env vars
     envs.push(("RANK".into(), rank.to_string().into()));


### PR DESCRIPTION
Fixes a regression introduced in #621. The Lorax launcher sets the environment variable PREDIBASE_API_TOKEN from the CLI flag --predibase-api-token. Unfortunately that PR overwrites the env var struct after the PREDIBASE_API_TOKEN has been set. :-(

Two deployments use this argument, 4421 and 4781. The latter uses an image that was build yesterday and so includes this bug, we will need to udpate it once this PR merges. (4421 is using an image that was built before this bug).