### PR TITLE
Fix seqlen bug for sliding window models like Mistral v0.1

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_mistral_modeling.py
@@ -618,7 +618,7 @@ class FlashMistralForCausalLM(torch.nn.Module):
             # Clamp in decode mode as paged attention requires clamped values whereas the flash attention
             # kernel requires the true values
             max_s = min(self.max_past, max_s)
-            seqlen = torch.clamp(seqlen, max=self.max_past)
+            seqlen = seqlen.clamp(max=self.max_past)
 
         inputs_embeds = self.embed_tokens(input_ids)
         hidden_states = self.model(

--- a/server/lorax_server/models/custom_modeling/flash_mixtral_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_mixtral_modeling.py
@@ -971,7 +971,7 @@ class FlashMixtralForCausalLM(torch.nn.Module):
             # Clamp in decode mode as paged attention requires clamped values whereas the flash attention
             # kernel requires the true values
             max_s = min(self.max_past, max_s)
-            seqlen = torch.clamp(seqlen, max=self.max_past)
+            seqlen = seqlen.clamp(max=self.max_past)
 
         hidden_states = self.model(
             input_ids,


### PR DESCRIPTION
Instead of doing `torch.clamp(seqlen ...` we need to use `seqlen.clamp` as seqlen is of class `Seqlen` and not a torch tensor.