### PR TITLE
Fix sliding window + compile bug

### DIFF
--- a/server/lorax_server/utils/attention/common.py
+++ b/server/lorax_server/utils/attention/common.py
@@ -49,5 +49,5 @@ class Seqlen:
         self.max_k = max_k
 
     def clamp(self, max):
-        self.input_lengths = torch.clamp(self.input_lengths, max=max)
+        self.input_lengths.data.clamp_(max=max)
         return self


### PR DESCRIPTION
The `clamp` method on `Seqlen` created a new tensor which CUDA graphs don't like. So, modified it to clamp in place.