### PR TITLE
Set maximum grpc message receive size to 2GiB

### DIFF
--- a/server/lorax_server/server.py
+++ b/server/lorax_server/server.py
@@ -408,7 +408,11 @@ def serve(
             interceptors=[
                 ExceptionInterceptor(),
                 UDSOpenTelemetryAioServerInterceptor(),
-            ]
+            ],
+            options=[
+                # Set the maximum possible message length: i32::MAX
+                ("grpc.max_receive_message_length", (1 << 31) - 1)
+            ],
         )
         generate_pb2_grpc.add_LoraxServiceServicer_to_server(LoraxService(model, Cache(), server_urls), server)
         SERVICE_NAMES = (


### PR DESCRIPTION
From https://github.com/huggingface/text-generation-inference/pull/2075.

Allows gRPC server to handle message payloads > 4MB