### PR TITLE
Use `--predibase-api-token` parameter when downloading

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1148,6 +1148,13 @@ fn download_convert_model(
         envs.push(("HUGGING_FACE_HUB_TOKEN".into(), api_token.into()))
     };
 
+    if let Ok(predibase_api_token) = &args.predibase_api_token {
+        envs.push((
+            "PREDIBASE_API_TOKEN".into(),
+            predibase_api_token.to_string().into(),
+        ));
+    }
+
     // If args.weights_cache_override is some, pass it to the download process
     // Useful when running inside a HuggingFace Inference Endpoint
     if let Some(weights_cache_override) = &args.weights_cache_override {

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1148,7 +1148,7 @@ fn download_convert_model(
         envs.push(("HUGGING_FACE_HUB_TOKEN".into(), api_token.into()))
     };
 
-    if let Ok(predibase_api_token) = &args.predibase_api_token {
+    if let Some(predibase_api_token) = &args.predibase_api_token {
         envs.push((
             "PREDIBASE_API_TOKEN".into(),
             predibase_api_token.to_string().into(),


### PR DESCRIPTION
The `--predibase-api-token` parameter provides a Predibase API token. It is currently used when serving inference requests, but not for the download step (when downloading base model weight or static adapters). This PR updates the token to be used for the download step as well.