### PR TITLE
fix: Make logprob field optional for response Pydantic validation

### DIFF
--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -270,7 +270,7 @@ class Token(BaseModel):
     # Token text
     text: str
     # Logprob
-    logprob: float
+    logprob: Optional[float]
     # Is the token a special token
     # Can be used to ignore tokens when concatenating
     special: bool


### PR DESCRIPTION
In some cases we observed `logprob=None` values being returned by the server. While this is unexpected and is being separately investigated, making the field optional here should keep this from blocking users.