### PR TITLE
Fix FlashInfer + Medusa bug

### DIFF
--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -1508,10 +1508,10 @@ class FlashCausalLM(Model):
             if FLASH_INFER:
                 block_tables = block_tables_to_ragged(
                     block_tables=block_tables,
-                    input_lengths=batch.input_lengths,
-                    cache_lengths=batch.cache_lengths,
-                    input_lengths_tensor=batch.input_lengths_tensor,
-                    cache_lengths_tensor=batch.cache_lengths_tensor,
+                    input_lengths=input_lengths.tolist(),
+                    cache_lengths=cache_lengths_tensor.tolist(),
+                    input_lengths_tensor=input_lengths,
+                    cache_lengths_tensor=cache_lengths_tensor,
                     max_current_length=max_s,
                 )
 

--- a/server/lorax_server/utils/flashinfer_attention.py
+++ b/server/lorax_server/utils/flashinfer_attention.py
@@ -209,10 +209,15 @@ def use_decode_state(
 
     token = decode_state.set(state)
 
+    indices = []
+    for l in input_lengths:
+            indices.append(torch.arange(l, dtype=torch.int32, device=input_lengths.device))
+    indices = torch.cat(indices) + block_tables[0]
+
     try:
         state.begin_forward(
             indptr=indptr,
-            indices=block_tables,
+            indices=indices,
             last_page_len=last_page_len,
             num_qo_heads=num_heads,
             num_kv_heads=num_kv_heads,

--- a/server/lorax_server/utils/flashinfer_attention.py
+++ b/server/lorax_server/utils/flashinfer_attention.py
@@ -209,15 +209,10 @@ def use_decode_state(
 
     token = decode_state.set(state)
 
-    indices = []
-    for l in input_lengths:
-            indices.append(torch.arange(l, dtype=torch.int32, device=input_lengths.device))
-    indices = torch.cat(indices) + block_tables[0]
-
     try:
         state.begin_forward(
             indptr=indptr,
-            indices=indices,
+            indices=block_tables,
             last_page_len=last_page_len,
             num_qo_heads=num_heads,
             num_kv_heads=num_kv_heads,


### PR DESCRIPTION
With vLLM's paged attention kernels `block_tables` is handled correctly and there's no other tensor used to index in this tensor. However, FlashInfer requires another tensor to index into `block_tables` (this is called as `indices` in the code) called `indptr`. For speculative tokens, we flatten the `block_tables` and treat the tokens as if they were a part of a different request altogether. The simplest fix for this problem is to make the behavior is FlashInfer similar to vLLM kernels. The current implementation is very hacky, and I am working on refining it.