### PR TITLE
Better health check

### DIFF
--- a/integration-tests/utils/docker_runner.py
+++ b/integration-tests/utils/docker_runner.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 
 def _init_client():
     try:
-        client = docker.DockerClient(base_url="unix:///var/run/docker.sock", version="auto")
+        client = docker.DockerClient(
+            base_url="unix:///var/run/docker.sock", version="auto"
+        )
         # Test the connection
         client.ping()
         logger.info("Successfully connected to Docker daemon")
@@ -20,7 +22,9 @@ def _init_client():
     except Exception as e:
         logger.error(f"Failed to connect to Docker daemon: {str(e)}")
         logger.error(f"Docker socket exists: {os.path.exists('/var/run/docker.sock')}")
-        logger.error(f"Docker socket permissions: {oct(os.stat('/var/run/docker.sock').st_mode)}")
+        logger.error(
+            f"Docker socket permissions: {oct(os.stat('/var/run/docker.sock').st_mode)}"
+        )
         raise
 
 
@@ -82,6 +86,8 @@ def run_lorax_container(config):
     try:
         logger.info("Waiting for container to be healthy")
         _wait_for_healthy(container)
+        startup_response = requests.get("http://localhost:8080/startup")
+        startup_response.raise_for_status()
         logger.info("Container is healthy")
         yield
     finally:

--- a/router/src/batch.rs
+++ b/router/src/batch.rs
@@ -290,7 +290,7 @@ pub(crate) trait BatchEntries: Sync + Send + Debug {
         batch: Batch,
         cached_batch: Option<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch>;
 
     async fn process_next(
@@ -298,7 +298,7 @@ pub(crate) trait BatchEntries: Sync + Send + Debug {
         client: &mut ShardedClient,
         batches: Vec<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch>;
 }
 
@@ -404,14 +404,14 @@ impl BatchEntries for GenerateBatchEntries {
         batch: Batch,
         cached_batch: Option<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         prefill(
             client,
             batch,
             cached_batch,
             &mut self.state.batch_entries,
-            &generation_health,
+            &inference_health,
         )
         .instrument(span)
         .await
@@ -422,13 +422,13 @@ impl BatchEntries for GenerateBatchEntries {
         client: &mut ShardedClient,
         batches: Vec<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         decode(
             client,
             batches,
             &mut self.state.batch_entries,
-            &generation_health,
+            &inference_health,
         )
         .instrument(span)
         .await
@@ -537,13 +537,13 @@ impl BatchEntries for EmbedBatchEntries {
         batch: Batch,
         _cached_batch: Option<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         embed(
             client,
             batch,
             &mut self.state.batch_entries,
-            &generation_health,
+            &inference_health,
         )
         .instrument(span)
         .await
@@ -554,7 +554,7 @@ impl BatchEntries for EmbedBatchEntries {
         _client: &mut ShardedClient,
         _batches: Vec<CachedBatch>,
         _span: Span,
-        _generation_health: &Arc<AtomicBool>,
+        _inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         // TODO(travis): send error (programming eroor) if we get here
         None
@@ -663,13 +663,13 @@ impl BatchEntries for ClassifyBatchEntries {
         batch: Batch,
         _cached_batch: Option<CachedBatch>,
         span: Span,
-        generation_health: &Arc<AtomicBool>,
+        inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         classify(
             client,
             batch,
             &mut self.state.batch_entries,
-            &generation_health,
+            &inference_health,
         )
         .instrument(span)
         .await
@@ -680,7 +680,7 @@ impl BatchEntries for ClassifyBatchEntries {
         _client: &mut ShardedClient,
         _batches: Vec<CachedBatch>,
         _span: Span,
-        _generation_health: &Arc<AtomicBool>,
+        _inference_health: &Arc<AtomicBool>,
     ) -> Option<CachedBatch> {
         // TODO(magdy): send error (programming eroor) if we get here
         None

--- a/router/src/health.rs
+++ b/router/src/health.rs
@@ -13,21 +13,21 @@ const BATCH_ID: u64 = u64::MAX;
 #[derive(Clone, Debug)]
 pub(crate) struct Health {
     client: ShardedClient,
-    generation_health: Arc<AtomicBool>,
+    inference_health: Arc<AtomicBool>,
     shard_info: ShardInfo,
 }
 
 impl Health {
     pub(crate) fn new(
         client: ShardedClient,
-        generation_health: Arc<AtomicBool>,
+        inference_health: Arc<AtomicBool>,
         shard_info: ShardInfo,
     ) -> Self {
         Self {
             #[allow(dead_code)]
             client,
             #[allow(dead_code)]
-            generation_health,
+            inference_health,
             shard_info,
         }
     }
@@ -36,59 +36,128 @@ impl Health {
         &self.shard_info
     }
 
+    pub(crate) async fn check_generation(&mut self) -> bool {
+        let generation_liveness_request = Request {
+            id: LIVENESS_ID,
+            inputs: "liveness".to_string(),
+            tokenized_inputs: None,
+            truncate: 10,
+            prefill_logprobs: false,
+            parameters: Some(NextTokenChooserParameters {
+                temperature: 1.0,
+                top_k: 0,
+                top_p: 1.0,
+                typical_p: 1.0,
+                do_sample: false,
+                seed: 0,
+                repetition_penalty: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
+                watermark: false,
+                adapter_id: "".to_string(),
+                schema: None,
+                return_k_alternatives: 0,
+            }),
+            stopping_parameters: Some(StoppingCriteriaParameters {
+                max_new_tokens: 1,
+                stop_sequences: vec![],
+                ignore_eos_token: false,
+            }),
+            adapter_index: 0,
+            // Block 0 is reserved for health checks
+            blocks: vec![0],
+            slots: (0..16).collect(),
+            cache_len: 0,
+            chunk_len: None,
+        };
+        let batch = Batch {
+            id: BATCH_ID,
+            requests: vec![generation_liveness_request],
+            size: 1,
+            max_tokens: 2,
+            max_blocks: 1,
+        };
+        // Skips the queue
+        self.client.prefill(batch, None).await.is_ok()
+    }
+
+    pub(crate) async fn check_classification(&mut self) -> bool {
+        let classify_request = Request {
+            id: LIVENESS_ID,
+            inputs: "San Francisco".to_string(),
+            tokenized_inputs: None,
+            truncate: 10,
+            prefill_logprobs: false,
+            parameters: None,
+            stopping_parameters: None,
+            adapter_index: 0,
+            blocks: vec![0],
+            slots: (0..16).collect(),
+            cache_len: 0,
+            chunk_len: None,
+        };
+        let batch = Batch {
+            id: BATCH_ID,
+            requests: vec![classify_request],
+            size: 1,
+            max_tokens: 2,
+            max_blocks: 1,
+        };
+        self.client.classify(batch).await.is_ok()
+    }
+
+    pub(crate) async fn check_embeddings(&mut self) -> bool {
+        let embed_request = Request {
+            id: LIVENESS_ID,
+            inputs: "San Francisco".to_string(),
+            tokenized_inputs: None,
+            truncate: 10,
+            prefill_logprobs: false,
+            parameters: None,
+            stopping_parameters: None,
+            adapter_index: 0,
+            blocks: vec![0],
+            slots: (0..16).collect(),
+            cache_len: 0,
+            chunk_len: None,
+        };
+        let batch = Batch {
+            id: BATCH_ID,
+            requests: vec![embed_request],
+            size: 1,
+            max_tokens: 2,
+            max_blocks: 1,
+        };
+        self.client.embed(batch).await.is_ok()
+    }
+
     #[allow(dead_code)]
     pub(crate) async fn check(&mut self) -> bool {
-        if self.generation_health.load(Ordering::SeqCst) {
+        if self.inference_health.load(Ordering::SeqCst) {
             // Generation is healthy, we only check that the shards are answering gRPC calls
             self.client.health().await.is_ok()
         } else {
             // Generation is unhealthy or have not sent any generation request yet
-
+            let mut value = false;
             // Dummy batch of 1 token and 1 generated token
-            let liveness_request = Request {
-                id: LIVENESS_ID,
-                inputs: "liveness".to_string(),
-                tokenized_inputs: None,
-                truncate: 10,
-                prefill_logprobs: false,
-                parameters: Some(NextTokenChooserParameters {
-                    temperature: 1.0,
-                    top_k: 0,
-                    top_p: 1.0,
-                    typical_p: 1.0,
-                    do_sample: false,
-                    seed: 0,
-                    repetition_penalty: 1.0,
-                    frequency_penalty: 0.0,
-                    presence_penalty: 0.0,
-                    watermark: false,
-                    adapter_id: "".to_string(),
-                    schema: None,
-                    return_k_alternatives: 0,
-                }),
-                stopping_parameters: Some(StoppingCriteriaParameters {
-                    max_new_tokens: 1,
-                    stop_sequences: vec![],
-                    ignore_eos_token: false,
-                }),
-                adapter_index: 0,
-                // Block 0 is reserved for health checks
-                blocks: vec![0],
-                slots: (0..16).collect(),
-                cache_len: 0,
-                chunk_len: None,
-            };
-            let batch = Batch {
-                id: BATCH_ID,
-                requests: vec![liveness_request],
-                size: 1,
-                max_tokens: 2,
-                max_blocks: 1,
-            };
-            // Skips the queue
-            let value = self.client.prefill(batch, None).await.is_ok();
-            // Update generation health
-            self.generation_health.store(value, Ordering::SeqCst);
+            if self.shard_info().supports_generation {
+                value = self.check_generation().await;
+                // Update generation health
+                self.inference_health.store(value, Ordering::SeqCst);
+            }
+
+            if self.shard_info().supports_classification {
+                value = self.check_classification().await;
+                // Update generation health
+                self.inference_health.store(value, Ordering::SeqCst);
+            }
+
+            if self.shard_info().supports_embeddings {
+                value = self.check_embeddings().await;
+                // Update generation health
+                self.inference_health.store(value, Ordering::SeqCst);
+            }
+
             value
         }
     }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -462,106 +462,17 @@ example = json ! ({"error": "unhealthy", "error_type": "healthcheck"})),
 )
 )]
 /// Health check method
-async fn health(
-    infer: Extension<Infer>,
-    health: Extension<Health>,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
-    if health.shard_info().supports_classification {
-        let classify_request = ClassifyRequest {
-            inputs: "San Francisco".to_string(),
-        };
-        match infer.classify(classify_request).await {
-            Ok(_) => {}
-            Err(error) => {
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: error.to_string(),
-                        error_type: error.error_type().to_string(),
-                    }),
-                ));
-            }
-        }
-    }
-    if health.shard_info().supports_embeddings {
-        let embed_request = EmbedRequest {
-            inputs: "San Francisco".to_string(),
-            parameters: Some(EmbedParameters {
-                adapter_id: None,
-                adapter_source: None,
-                adapter_parameters: None,
-                api_token: None,
+async fn health(mut health: Extension<Health>) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    match health.check().await {
+        true => Ok(()),
+        false => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "unhealthy".to_string(),
+                error_type: "healthcheck".to_string(),
             }),
-        };
-        match infer.embed(embed_request).await {
-            Ok(_) => {}
-            Err(error) => {
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: error.to_string(),
-                        error_type: error.error_type().to_string(),
-                    }),
-                ));
-            }
-        }
+        )),
     }
-    if health.shard_info().supports_generation {
-        let generate_request = GenerateRequest {
-            inputs: "Who?".to_string(),
-            parameters: GenerateParameters {
-                adapter_id: None,
-                adapter_source: None,
-                adapter_parameters: None,
-                api_token: None,
-                best_of: None,
-                temperature: None,
-                top_k: None,
-                top_p: None,
-                typical_p: None,
-                do_sample: false,
-                seed: None,
-                repetition_penalty: None,
-                frequency_penalty: None,
-                presence_penalty: None,
-                watermark: false,
-                return_full_text: None,
-                stop: vec![],
-                truncate: None,
-                details: false,
-                decoder_input_details: false,
-                return_k_alternatives: None,
-                apply_chat_template: false,
-                response_format: None,
-                max_new_tokens: Some(1),
-                ignore_eos_token: false,
-            },
-            add_special_tokens: true,
-        };
-        match infer.generate(generate_request).await {
-            Ok(response) => {
-                if response.generated_text.text.len() == 0 {
-                    return Err((
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(ErrorResponse {
-                            error: "Empty generation".to_string(),
-                            error_type: "failed healthcheck".to_string(),
-                        }),
-                    ));
-                }
-            }
-            Err(error) => {
-                return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: error.to_string(),
-                        error_type: error.error_type().to_string(),
-                    }),
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Generate tokens

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1512,7 +1512,7 @@ pub async fn run(
     let info_routes = Router::new()
         .route("/", get(health))
         // Base Health route
-        .route("/ready", get(is_startup_ready))
+        .route("/startup", get(is_startup_ready))
         .route("/health", get(health))
         .route("/info", get(get_model_info))
         // AWS Sagemaker health route


### PR DESCRIPTION
- Rename generation_health to inference_health (We store health of gen, embed, classify here) 
- Make /health a very fast and pass through endpoint that just returns the value of the inference_health bool
- Add /startup which will interface with the k8s startup probe and this does a full round trip of the request