### PR TITLE
Support JSON response for /metrics endpoint, add client method for metrics

### DIFF
--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -561,7 +561,6 @@ class Client:
         Returns:
             MetricsResponse: metrics in the specified format
         """
-        # Simplified header assignment
         headers = {
             **(self.headers or {}),
             "Accept": "application/json" if format == "json" else "text/plain",
@@ -975,7 +974,6 @@ class AsyncClient:
         """
         Get the metrics of the server
         """
-        # Simplified header assignment
         headers = {
             **(self.headers or {}),
             "Accept": "application/json" if format == "json" else "text/plain",

--- a/clients/python/lorax/client.py
+++ b/clients/python/lorax/client.py
@@ -17,7 +17,6 @@ from lorax.types import (
     ResponseFormat,
     EmbedResponse,
     ClassifyResponse,
-    MetricsResponse,
 )
 from lorax.errors import parse_error
 
@@ -550,7 +549,7 @@ class Client:
 
     def metrics(
         self, format: Optional[Literal["json", "prometheus"]] = "prometheus"
-    ) -> MetricsResponse:
+    ) -> Union[str, dict]:
         """
         Get the metrics of the model
 
@@ -970,7 +969,7 @@ class AsyncClient:
 
     async def metrics(
         self, format: Literal["json", "prometheus"] = "prometheus"
-    ) -> MetricsResponse:
+    ) -> Union[str, dict]:
         """
         Get the metrics of the server
         """
@@ -990,5 +989,4 @@ class AsyncClient:
                     raise parse_error(
                         resp.status, payload, resp.headers if LORAX_DEBUG_MODE else None
                     )
-
-                return MetricsResponse(metrics=payload)
+                return payload

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -52,7 +52,9 @@ class MergedAdapters(BaseModel):
     @field_validator("majority_sign_method")
     def validate_majority_sign_method(cls, v):
         if v is not None and v not in MAJORITY_SIGN_METHODS:
-            raise ValidationError(f"`majority_sign_method` must be one of {MAJORITY_SIGN_METHODS}")
+            raise ValidationError(
+                f"`majority_sign_method` must be one of {MAJORITY_SIGN_METHODS}"
+            )
         return v
 
 
@@ -64,7 +66,9 @@ class ResponseFormat(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
     type: ResponseFormatType
-    schema_spec: Optional[Union[Dict[str, Any], OrderedDict]] = Field(None, alias="schema")
+    schema_spec: Optional[Union[Dict[str, Any], OrderedDict]] = Field(
+        None, alias="schema"
+    )
 
 
 class Parameters(BaseModel):
@@ -121,13 +125,17 @@ class Parameters(BaseModel):
         adapter_id = self.adapter_id
         merged_adapters = self.merged_adapters
         if adapter_id is not None and merged_adapters is not None:
-            raise ValidationError("you must specify at most one of `adapter_id` or `merged_adapters`")
+            raise ValidationError(
+                "you must specify at most one of `adapter_id` or `merged_adapters`"
+            )
         return self
 
     @field_validator("adapter_source")
     def valid_adapter_source(cls, v):
         if v is not None and v not in ADAPTER_SOURCES:
-            raise ValidationError(f"`adapter_source={v}` must be one of {ADAPTER_SOURCES}")
+            raise ValidationError(
+                f"`adapter_source={v}` must be one of {ADAPTER_SOURCES}"
+            )
         return v
 
     @field_validator("best_of")
@@ -215,8 +223,15 @@ class Request(BaseModel):
     @field_validator("stream")
     def valid_best_of_stream(cls, field_value, values):
         parameters = values.data["parameters"]
-        if parameters is not None and parameters.best_of is not None and parameters.best_of > 1 and field_value:
-            raise ValidationError("`best_of` != 1 is not supported when `stream` == True")
+        if (
+            parameters is not None
+            and parameters.best_of is not None
+            and parameters.best_of > 1
+            and field_value
+        ):
+            raise ValidationError(
+                "`best_of` != 1 is not supported when `stream` == True"
+            )
         return field_value
 
 
@@ -237,8 +252,15 @@ class BatchRequest(BaseModel):
     @field_validator("stream")
     def valid_best_of_stream(cls, field_value, values):
         parameters = values.data["parameters"]
-        if parameters is not None and parameters.best_of is not None and parameters.best_of > 1 and field_value:
-            raise ValidationError("`best_of` != 1 is not supported when `stream` == True")
+        if (
+            parameters is not None
+            and parameters.best_of is not None
+            and parameters.best_of > 1
+            and field_value
+        ):
+            raise ValidationError(
+                "`best_of` != 1 is not supported when `stream` == True"
+            )
         return field_value
 
 
@@ -370,6 +392,12 @@ class EmbedResponse(BaseModel):
     # Embeddings
     embeddings: Optional[List[float]]
 
+
 class ClassifyResponse(BaseModel):
     # Classifications
     entities: Optional[List[dict]]
+
+
+class MetricsResponse(BaseModel):
+    # Metrics (can be in JSON or Prometheus [string] format)
+    metrics: Optional[str | dict]

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -400,4 +400,4 @@ class ClassifyResponse(BaseModel):
 
 class MetricsResponse(BaseModel):
     # Metrics (can be in JSON or Prometheus [string] format)
-    metrics: Optional[str | dict]
+    metrics: Optional[Union[str, dict]]

--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -396,8 +396,3 @@ class EmbedResponse(BaseModel):
 class ClassifyResponse(BaseModel):
     # Classifications
     entities: Optional[List[dict]]
-
-
-class MetricsResponse(BaseModel):
-    # Metrics (can be in JSON or Prometheus [string] format)
-    metrics: Optional[Union[str, dict]]

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1898,6 +1898,10 @@ async fn classify(
         "lorax_request_inference_duration",
         inference_time.as_secs_f64()
     );
+    metrics::histogram!(
+        "lorax_request_classify_output_count",
+        response.predictions.len() as f64
+    );
 
     tracing::debug!("Output: {:?}", response.predictions);
     tracing::info!("Success");

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1216,26 +1216,20 @@ fn parse_text_to_metrics(text: &str) -> HashMap<String, MetricFamily> {
             }
         }
 
-        // Parse metric line
+        // Parse metric line if it belongs to current metric family
         if let Some(metric_family) = metrics.get_mut(&current_metric) {
-            // Split into name and value parts
             let mut parts = line.split_whitespace();
-            if let (Some(name_part), Some(value_str)) = (parts.next(), parts.next()) {
+            if let (Some(metric_name), Some(value_str)) = (parts.next(), parts.next()) {
                 if let Ok(value) = value_str.parse::<f64>() {
-                    let key = if name_part.contains('{') {
-                        name_part.to_string()
-                    } else if name_part.ends_with("_sum") {
-                        "sum".to_string()
-                    } else if name_part.ends_with("_count") {
-                        "count".to_string()
-                    } else {
-                        "".to_string()
+                    let key = match metric_name {
+                        name if name.contains('{') => name.to_string(),
+                        name if name.ends_with("_sum") => "sum".to_string(),
+                        name if name.ends_with("_count") => "count".to_string(),
+                        _ => "".to_string()
                     };
 
-                    metric_family.data.push(DataPoint {
-                        key,
-                        value,
-                    });
+                    // Add the parsed metric data point
+                    metric_family.data.push(DataPoint { key, value });
                 }
             }
         }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -35,6 +35,7 @@ use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use once_cell::sync::OnceCell;
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp;
 use std::collections::HashMap;
@@ -54,8 +55,6 @@ use tower_http::cors::{
 use tracing::{info_span, instrument, Instrument};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
-use serde::{Deserialize, Serialize};
-
 
 pub static DEFAULT_ADAPTER_SOURCE: OnceCell<String> = OnceCell::new();
 
@@ -1207,10 +1206,13 @@ fn parse_text_to_metrics(text: &str) -> HashMap<String, MetricFamily> {
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 4 {
                 current_metric = parts[2].to_string();
-                metrics.insert(current_metric.clone(), MetricFamily {
-                    r#type: parts[3].to_string(), // Metric type -> histogram, counter, etc
-                    data: Vec::new(),
-                });
+                metrics.insert(
+                    current_metric.clone(),
+                    MetricFamily {
+                        r#type: parts[3].to_string(), // Metric type -> histogram, counter, etc
+                        data: Vec::new(),
+                    },
+                );
                 continue;
             }
         }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -1195,7 +1195,6 @@ struct DataPoint {
 fn parse_text_to_metrics(text: &str) -> HashMap<String, MetricFamily> {
     let mut metrics = HashMap::new();
     let mut current_metric = String::new();
-    let mut current_type = String::new();
 
     for line in text.lines() {
         if line.is_empty() {
@@ -1203,13 +1202,13 @@ fn parse_text_to_metrics(text: &str) -> HashMap<String, MetricFamily> {
         }
 
         if line.starts_with("# TYPE ") {
-            // Extract metric name and type from TYPE declaration
+            // Extract metric name from TYPE declaration
+            // # TYPE <metric_name> <metric_type>
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 4 {
                 current_metric = parts[2].to_string();
-                current_type = parts[3].to_string();
                 metrics.insert(current_metric.clone(), MetricFamily {
-                    r#type: current_type.clone(),
+                    r#type: parts[3].to_string(), // Metric type -> histogram, counter, etc
                     data: Vec::new(),
                 });
                 continue;
@@ -1225,7 +1224,7 @@ fn parse_text_to_metrics(text: &str) -> HashMap<String, MetricFamily> {
                         name if name.contains('{') => name.to_string(),
                         name if name.ends_with("_sum") => "sum".to_string(),
                         name if name.ends_with("_count") => "count".to_string(),
-                        _ => "".to_string()
+                        _ => "".to_string(),
                     };
 
                     // Add the parsed metric data point


### PR DESCRIPTION
This PR adds a new `metrics` method to both the async and sync LoRAX client objects that returns a nearly equivalent payload to what the `/metrics` endpoint returns.

By default, the `/metrics` endpoint returns a response in `plain/text` format and in a format compatible with Prometheus. This PR modifies that endpoint to support a new optional query parameter called `format` that can optionally be set to JSON  or just requires the `application/json` header. 

```sh
curl -X GET "http://127.0.0.1:8080/metrics" -H "Accept: application/json"
```

On the Python client side, you can just call `client.metrics(format="json")` to get the relevant response back:

```python
from lorax import Client

endpoint_url = "http://127.0.0.1:8080"
client = Client(endpoint_url)

metrics = client.metrics(format="json") # just call .metrics() if you want it in prometheus format
```

The structure follows this format:
```
{
        parent_metric_name: {
                "type": histogram | gauge | summary | counter
                "data": [
                     {"key": X, "value": Y},
                     {"key": X, "value": Y},
                     ...
                ]
        }
}
```

For metrics that are histograms, you will also find a `sum` and `count` key in the data objects.

Here's an example snippet when grabbing this output:

```
{'lorax_batch_current_max_tokens': {'data': [{'key': '', 'value': 0.0}],
                                    'type': 'gauge'},
 'lorax_batch_current_size': {'data': [{'key': '', 'value': 0.0}],
                              'type': 'gauge'},
 'lorax_batch_inference_count': {'data': [{'key': 'lorax_batch_inference_count{method="decode"}',
                                           'value': 508.0},
                                          {'key': 'lorax_batch_inference_count{method="prefill"}',
                                           'value': 4.0}],
                                 'type': 'counter'},
.....
 'lorax_request_skipped_tokens': {'data': [{'key': 'lorax_request_skipped_tokens{quantile="0"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="0.5"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="0.9"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="0.95"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="0.99"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="0.999"}',
                                            'value': 0.0},
                                           {'key': 'lorax_request_skipped_tokens{quantile="1"}',
                                            'value': 0.0},
                                           {'key': 'sum', 'value': 0.0},
                                           {'key': 'count', 'value': 512.0}],
                                                         'type': 'summary'}
....
}
```