### PR TITLE
Fix lm_head with tied word embeddings for Qwen2 and Qwen2.5

### DIFF
--- a/server/lorax_server/models/custom_modeling/flash_qwen2_modeling.py
+++ b/server/lorax_server/models/custom_modeling/flash_qwen2_modeling.py
@@ -485,10 +485,15 @@ class FlashQwen2ForCausalLM(torch.nn.Module):
         self.config = config
 
         self.model = FlashQwen2Model(prefix, config, weights)
+        if config.tie_word_embeddings:
+            suffix = "model.embed_tokens"
+        else:
+            suffix = "lm_head"
+
         self.lm_head = MultiAdapterHead.load(
             TensorParallelHead.load(
                 config,
-                prefix=prepend(prefix, "lm_head"),
+                prefix=suffix if not prefix else f"{prefix}.{suffix}",
                 weights=weights,
             ),
             0,


### PR DESCRIPTION
Fixes the following stack trace for Qwen2 and Qwen2.5 models such as Qwen/Qwen2.5-3B-Instruct since `tie_word_embeddings` is true:

```sh
ile "/opt/conda/lib/python3.10/site-packages/lorax_server/models/flash_qwen2.py", line 86, in __init__
    model = FlashQwen2ForCausalLM(config, weights)

  File "/opt/conda/lib/python3.10/site-packages/lorax_server/models/custom_modeling/flash_qwen2_modeling.py", line 452, in __init__
    TensorParallelHead.load(

  File "/opt/conda/lib/python3.10/site-packages/lorax_server/layers/tensor_parallel.py", line 36, in load
    weight = weights.get_tensor(f"{prefix}.weight")

  File "/opt/conda/lib/python3.10/site-packages/lorax_server/utils/weights.py", line 383, in get_tensor
    filename, tensor_name = self.get_filename(tensor_name)

  File "/opt/conda/lib/python3.10/site-packages/lorax_server/utils/weights.py", line 370, in get_filename
    raise RuntimeError(f"weight {tensor_name} does not exist")

RuntimeError: weight lm_head.weight does not exist
```

Sample Input:

```sh
curl 127.0.0.1:8080/generate \
    -X POST \
    -d '{
        "inputs": "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?",
        "parameters": {
            "max_new_tokens": 256
        }
    }' \
    -H 'Content-Type: application/json'
```

Sample Output:

```txt
To determine the total number of clips Natalia sold in April and May, we need to follow these steps:

1. Identify the number of clips sold in April.
2. Calculate the number of clips sold in May.
3. Add the number of clips sold in April and May together.

First, we know that Natalia sold 48 clips in April. In May, she sold half as many clips as she did in April. Therefore, the number of clips sold in May is:
\[
\frac{48}{2} = 24
\]

Next, we add the number of clips sold in April and May to find the total number of clips sold:
\[
48 + 24 = 72
\]

Thus, the total number of clips Natalia sold in April and May is \(\boxed{72}\).
```

Closes #726 