### PR TITLE
Add eager flag and set compile to be always true

### DIFF
--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -753,8 +753,7 @@ fn shard_manager(
     }
 
     if compile && eager {
-        tracing::error!("Cannot use both --compile and --eager at the same time.");
-        return;
+        panic!("Cannot use both --compile and --eager at the same time.");
     }
 
     // Speculative decoding

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -344,14 +344,14 @@ struct Args {
     /// This will speed up decoding but increase GPU memory usage.
     /// Only use either `--compile` or `--eager`. Using both at the same time will
     /// result in an error.
-    #[clap(default_value = "true", long, env, value_enum)]
+    #[clap(long, env, value_enum)]
     compile: bool,
 
     /// Whether you want to run the model in eager mode, without
     /// CUDA mode compilation, or run it with compilation.
     /// Only use either `--compile` or `--eager`. Using both at the same time will
     /// result in an error.
-    #[clap(default_value = "false", long, env, value_enum)]
+    #[clap(long, env, value_enum)]
     eager: bool,
 
     // The maximum batch size past which CUDA graphs are disabled.
@@ -748,12 +748,13 @@ fn shard_manager(
     }
 
     // CUDA graph compilation
-    if compile && !eager {
+    if !eager {
         shard_args.push("--compile".to_string());
     }
 
-    if (compile && eager) || (!compile && !eager) {
-        panic!("Cannot use both --compile and --eager at the same time.");
+    if compile && eager {
+        tracing::error!("Cannot use both --compile and --eager at the same time.");
+        return;
     }
 
     // Speculative decoding

--- a/server/lorax_server/models/bloom.py
+++ b/server/lorax_server/models/bloom.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Tuple, Type
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -66,7 +67,7 @@ class BLOOMSharded(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with Bloom")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():

--- a/server/lorax_server/models/causal_lm.py
+++ b/server/lorax_server/models/causal_lm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Type
 
 import torch
+from loguru import logger
 from opentelemetry import trace
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase
 
@@ -499,7 +500,7 @@ class CausalLM(Model):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with CausalLM")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         if torch.cuda.is_available():
             device = torch.device("cuda")

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -1181,9 +1181,7 @@ class FlashCausalLM(Model):
             SLIDING_WINDOW = sliding_window
             SLIDING_WINDOW_BLOCKS = math.ceil(sliding_window / BLOCK_SIZE)
 
-        self.compile = compile and self.supports_cuda_graph_compilation
-        if compile and not self.supports_cuda_graph_compilation:
-            logger.info("Model does not support CUDA graph compilation. Skipping compilation.")
+        self.compile = compile
 
         self.model_graph_wrapper: GraphCache = None
         self.kv_cache = []

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -1182,6 +1182,9 @@ class FlashCausalLM(Model):
             SLIDING_WINDOW_BLOCKS = math.ceil(sliding_window / BLOCK_SIZE)
 
         self.compile = compile and self.supports_cuda_graph_compilation
+        if compile and not self.supports_cuda_graph_compilation:
+            logger.info("Model does not support CUDA graph compilation. Skipping compilation.")
+
         self.model_graph_wrapper: GraphCache = None
         self.kv_cache = []
 

--- a/server/lorax_server/models/flash_causal_lm.py
+++ b/server/lorax_server/models/flash_causal_lm.py
@@ -1181,7 +1181,7 @@ class FlashCausalLM(Model):
             SLIDING_WINDOW = sliding_window
             SLIDING_WINDOW_BLOCKS = math.ceil(sliding_window / BLOCK_SIZE)
 
-        self.compile = compile
+        self.compile = compile and self.supports_cuda_graph_compilation
         self.model_graph_wrapper: GraphCache = None
         self.kv_cache = []
 

--- a/server/lorax_server/models/galactica.py
+++ b/server/lorax_server/models/galactica.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Type
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -161,7 +162,7 @@ class GalacticaSharded(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with GalacticaSharded")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():

--- a/server/lorax_server/models/gpt_neox.py
+++ b/server/lorax_server/models/gpt_neox.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -29,7 +30,7 @@ class GPTNeoxSharded(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with GPT-NeoX")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():

--- a/server/lorax_server/models/model.py
+++ b/server/lorax_server/models/model.py
@@ -229,6 +229,10 @@ class Model(ABC):
             )
 
     @property
+    def supports_cuda_graph_compilation(self) -> bool:
+        return True
+
+    @property
     def supports_adapter_loading(self) -> bool:
         return False
 

--- a/server/lorax_server/models/mpt.py
+++ b/server/lorax_server/models/mpt.py
@@ -5,6 +5,7 @@ from typing import Optional, Type
 import torch
 import torch.distributed
 from huggingface_hub import hf_hub_download
+from loguru import logger
 from opentelemetry import trace
 from transformers import AutoTokenizer, PretrainedConfig, PreTrainedTokenizerBase
 
@@ -58,7 +59,7 @@ class MPTSharded(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with MPT")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():

--- a/server/lorax_server/models/opt.py
+++ b/server/lorax_server/models/opt.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -27,7 +28,7 @@ class OPTSharded(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with OPT")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():

--- a/server/lorax_server/models/rw.py
+++ b/server/lorax_server/models/rw.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple
 
 import torch
+from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from lorax_server.models.causal_lm import CausalLM
@@ -17,7 +18,7 @@ class RW(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with RW")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         if torch.cuda.is_available():
             device = torch.device("cuda")

--- a/server/lorax_server/models/santacoder.py
+++ b/server/lorax_server/models/santacoder.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from lorax_server.models.causal_lm import CausalLM
@@ -24,7 +25,7 @@ class SantaCoder(CausalLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with SantaCoder")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         if torch.cuda.is_available():
             device = torch.device("cuda")

--- a/server/lorax_server/models/seq2seq_lm.py
+++ b/server/lorax_server/models/seq2seq_lm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Type
 
 import torch
+from loguru import logger
 from opentelemetry import trace
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, PreTrainedTokenizerBase
 
@@ -488,7 +489,7 @@ class Seq2SeqLM(Model):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with Seq2SeqLM")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         if torch.cuda.is_available():
             device = torch.device("cuda")

--- a/server/lorax_server/models/t5.py
+++ b/server/lorax_server/models/t5.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 
 import torch
 import torch.distributed
+from loguru import logger
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -29,7 +30,7 @@ class T5Sharded(Seq2SeqLM):
         trust_remote_code: bool = False,
     ):
         if compile:
-            raise ValueError("`--compile` is not supported with T5")
+            logger.info(f"Model {model_id} does not support CUDA graph compilation. Skipping compilation.")
 
         self.process_group, rank, world_size = initialize_torch_distributed()
         if torch.cuda.is_available():


### PR DESCRIPTION
Adds a new flag to the launcher called `--eager` that allows users to disable CUDA graph compilation which is enabled by default. Also, sets `--compile` to always be true. Finally, tested that compile works with following list of models, and added a property called `supports_cuda_graph_compilation` that individual models can set to disable compilation.

* microsoft/phi-4
* mistralai/Mistral-7B-Instruct-v0.2
* meta-llama/Llama-3.2-11B-Vision-Instruct
* meta-llama/Llama-3.1-8B-Instruct
* Qwen/Qwen2.5-7B-Instruct
* upstage/SOLAR-10.7B-v1.0
* ibm-granite/granite-3.1-8b-instruct