### PR TITLE
Stricter tracing inclusions

### DIFF
--- a/.github/workflows/router_tests.yaml
+++ b/.github/workflows/router_tests.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.79.0
+          toolchain: 1.83.0
           override: true
           components: rustfmt, clippy
       - name: Install Protoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Rust builder
-FROM lukemathwalker/cargo-chef:latest-rust-1.79 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.83 AS chef
 WORKDIR /usr/src
 
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

--- a/router/src/infer.rs
+++ b/router/src/infer.rs
@@ -276,7 +276,7 @@ impl Infer {
     }
 
     /// Add a new request to the queue and return a stream of InferStreamResponse
-    #[instrument(skip(self))]
+    #[instrument(skip_all,fields(parameters = ? request.parameters))]
     pub(crate) async fn generate_stream(
         &self,
         request: GenerateRequest,
@@ -400,7 +400,7 @@ impl Infer {
     }
 
     /// Add a new request to the queue and return a InferResponse
-    #[instrument(skip(self))]
+    #[instrument(skip_all,fields(parameters = ? request.parameters))]
     pub(crate) async fn generate(
         &self,
         request: GenerateRequest,
@@ -488,7 +488,7 @@ impl Infer {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all,fields(parameters = ? request.parameters))]
     pub(crate) async fn embed(&self, request: EmbedRequest) -> Result<EmbedResponse, InferError> {
         // Limit concurrent requests by acquiring a permit from the semaphore
         let _permit = self
@@ -618,7 +618,7 @@ impl Infer {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn classify(
         &self,
         request: ClassifyRequest,
@@ -731,7 +731,7 @@ impl Infer {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all)]
     pub(crate) async fn classify_batch(
         &self,
         request: BatchClassifyRequest,
@@ -861,7 +861,7 @@ impl Infer {
         }
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip_all,fields(parameters = ? request.parameters))]
     pub(crate) async fn embed_batch(
         &self,
         request: BatchEmbedRequest,
@@ -996,7 +996,7 @@ impl Infer {
 
     /// Add best_of new requests to the queue and return a InferResponse of the sequence with
     /// the highest log probability per token
-    #[instrument(skip(self))]
+    #[instrument(skip_all,fields(parameters = ? request.parameters, best_of, prefix_caching))]
     pub(crate) async fn generate_best_of(
         &self,
         request: GenerateRequest,

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -22,7 +22,7 @@ use crate::{
 use axum::extract::Extension;
 use axum::extract::Query;
 use axum::http::header;
-use axum::http::{HeaderMap, Method, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -2081,7 +2081,7 @@ async fn tokenize(
 
 // Implements Tracing Value for Header Value, to support recording header values
 impl tracing::Value for HeaderValue {
-    fn record(&self, key: &tracing::field::Field, visitor: &mut dyn Visit) {
+    fn record(&self, key: &tracing::field::Field, visitor: &mut dyn tracing::field::Visit) {
         // Convert HeaderValue to a string representation safely
         let value_str = self.to_str().unwrap_or("<invalid utf-8>");
         key.record_str(value_str, visitor);

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -104,7 +104,7 @@ async fn compat_generate(
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     // Log some useful headers to the span.
     let span = tracing::Span::current();
-    trace_headers(req_headers, &span);
+    trace_headers(req_headers.clone(), &span);
 
     let mut req = req.0;
 
@@ -174,7 +174,7 @@ async fn completions_v1(
     req: Json<CompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
-    trace_headers(req_headers, &span);
+    trace_headers(req_headers.clone(), &span);
     let mut req = req.0;
     if req.model == info.model_id.as_str() {
         // Allow user to specify the base model, but treat it as an empty adapter_id
@@ -261,7 +261,7 @@ async fn chat_completions_v1(
     req: Json<ChatCompletionRequest>,
 ) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
-    trace_headers(req_headers, &span);
+    trace_headers(req_headers.clone(), &span);
     let mut req = req.0;
     let model_id = info.model_id.clone();
     if req.model == info.model_id.as_str() {
@@ -651,7 +651,7 @@ async fn generate(
     mut req: Json<GenerateRequest>,
 ) -> Result<(HeaderMap, Json<GenerateResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
-    trace_headers(req_headers, &span);
+    trace_headers(req_headers.clone(), &span);
     let start_time = Instant::now();
     metrics::increment_counter!("lorax_request_count");
 
@@ -2084,7 +2084,7 @@ impl tracing::Value for HeaderValue {
     fn record(&self, key: &tracing::field::Field, visitor: &mut dyn tracing::field::Visit) {
         // Convert HeaderValue to a string representation safely
         let value_str = self.to_str().unwrap_or("<invalid utf-8>");
-        key.record_str(value_str, visitor);
+        visitor.record_str(key, value_str);
     }
 }
 

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -2079,6 +2079,15 @@ async fn tokenize(
     }
 }
 
+// Implements Tracing Value for Header Value, to support recording header values
+impl tracing::Value for HeaderValue {
+    fn record(&self, key: &tracing::field::Field, visitor: &mut dyn Visit) {
+        // Convert HeaderValue to a string representation safely
+        let value_str = self.to_str().unwrap_or("<invalid utf-8>");
+        key.record_str(value_str, visitor);
+    }
+}
+
 fn trace_headers(headers: HeaderMap, span: &tracing::Span) {
     headers
         .get("x-predibase-tenant")

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -22,7 +22,7 @@ use crate::{
 use axum::extract::Extension;
 use axum::extract::Query;
 use axum::http::header;
-use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
+use axum::http::{HeaderMap, Method, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -2080,7 +2080,7 @@ async fn tokenize(
 }
 
 // Implements Tracing Value for Header Value, to support recording header values
-impl tracing::Value for HeaderValue {
+impl tracing::Value for axum::http::HeaderValue {
     fn record(&self, key: &tracing::field::Field, visitor: &mut dyn tracing::field::Visit) {
         // Convert HeaderValue to a string representation safely
         let value_str = self.to_str().unwrap_or("<invalid utf-8>");

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -2079,23 +2079,14 @@ async fn tokenize(
     }
 }
 
-// Implements Tracing Value for Header Value, to support recording header values
-impl tracing::Value for axum::http::HeaderValue {
-    fn record(&self, key: &tracing::field::Field, visitor: &mut dyn tracing::field::Visit) {
-        // Convert HeaderValue to a string representation safely
-        let value_str = self.to_str().unwrap_or("<invalid utf-8>");
-        visitor.record_str(key, value_str);
-    }
-}
-
 fn trace_headers(headers: HeaderMap, span: &tracing::Span) {
     headers
         .get("x-predibase-tenant")
-        .map(|value| span.record("x-predibase-tenant", value));
+        .map(|value| span.record("x-predibase-tenant", value.to_str().unwrap_or("unknown")));
     headers
         .get("user-agent")
-        .map(|value| span.record("user-agent", value));
+        .map(|value| span.record("user-agent", value.to_str().unwrap_or("unknown")));
     headers
         .get("x-b3-traceid")
-        .map(|value| span.record("x-b3-traceid", value));
+        .map(|value| span.record("x-b3-traceid", value.to_str().unwrap_or("")));
 }

--- a/router/src/server.rs
+++ b/router/src/server.rs
@@ -80,8 +80,18 @@ example = json ! ({"error": "Input validation error"})),
 example = json ! ({"error": "Incomplete generation"})),
 )
 )]
-#[instrument(skip(infer, req))]
-async fn compat_generate(
+#[instrument(
+skip_all,
+fields(
+parameters = ? req.0.parameters,
+total_time,
+validation_time,
+queue_time,
+inference_time,
+time_per_token,
+seed,
+)
+)]async fn compat_generate(
     default_return_full_text: Extension<bool>,
     infer: Extension<Infer>,
     info: Extension<Info>,
@@ -147,7 +157,7 @@ example = json ! ({"error": "Input validation error"})),
 example = json ! ({"error": "Incomplete generation"})),
 )
 )]
-#[instrument(skip(infer, req))]
+#[instrument(skip(infer, req, req_headers))]
 async fn completions_v1(
     default_return_full_text: Extension<bool>,
     infer: Extension<Infer>,
@@ -232,7 +242,7 @@ example = json ! ({"error": "Input validation error"})),
 example = json ! ({"error": "Incomplete generation"})),
 )
 )]
-#[instrument(skip(infer, req))]
+#[instrument(skip(infer, req, req_headers))]
 async fn chat_completions_v1(
     default_return_full_text: Extension<bool>,
     infer: Extension<Infer>,


### PR DESCRIPTION
Stricter tracing filters for internal methods, so we don't have large unwieldy error messages. 

Added back some useful headers to the tracing on the methods I removed all headers for. In general, headers might contain stuff like API tokens so those shouldn't be traced. 