### PR TITLE
Add ability to specify revision in `model_id` flag using model@revision format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
       - 'main'
     tags:
       - "v*"
+  pull_request:
 
 jobs:
   build-test-push-image:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,6 @@ on:
       - 'main'
     tags:
       - "v*"
-  pull_request:
 
 jobs:
   build-test-push-image:

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1002,7 +1002,10 @@ fn shard_manager(
 
 // Parse the model_id to extract the model and revision (in model@revision format). If the model_id string doesn't
 // encode a revision, return revision_fallback for revision (which may itself be None).
-fn get_model_and_revision(model_id: &str, revision_fallback: Option<String>) -> (String, Option<String>) {
+fn get_model_and_revision(
+    model_id: &str,
+    revision_fallback: Option<String>,
+) -> (String, Option<String>) {
     let mut parts = model_id.split('@');
     let model_id = parts.next().unwrap().to_string();
     let revision = parts.next().map(|s| s.to_string()).or(revision_fallback);

--- a/launcher/src/main.rs
+++ b/launcher/src/main.rs
@@ -1624,7 +1624,7 @@ fn main() -> Result<(), LauncherError> {
 
     if args.model_id.contains('@') && args.revision.is_some() {
         return Err(LauncherError::ArgumentValidation(
-            "Cannot specify a revision in both the --model_id and --revision flags".to_string()
+            "Cannot specify a revision in both the --model_id and --revision flags".to_string(),
         ));
     }
     // Extract the model id and revision from the model_id flag, if encoded in model@revision format (otherwise this


### PR DESCRIPTION
Adds support to specify a model revision in the format `model@revision` as part of the `--model-id` flag. Mutually exclusive with the `--revision` flag.

Tested by deploying an LLM specifying a non-default revision and verified that we fetched the desired version from HF.