### PR TITLE
Fix crash when `--adapter-id` is not set and `--adapter-source pbase` is specified

### DIFF
--- a/server/lorax_server/server.py
+++ b/server/lorax_server/server.py
@@ -292,7 +292,7 @@ def serve(
             local_url = unix_socket_template.format(uds_path, 0)
             server_urls = [local_url]
 
-        if adapter_source == PBASE:
+        if adapter_source == PBASE and adapter_id != "":
             logger.info("Got a PBASE adapter source, mapping model ID to S3")
             api_token = os.getenv("PREDIBASE_API_TOKEN")
             adapter_id = map_pbase_model_id_to_s3(adapter_id, api_token)


### PR DESCRIPTION
If you specify `--adapter-source pbase` but leave `--adapter-id` blank, we try to fetch adapter information for an empty string, which causes a crash. Fix this.