### PR TITLE
fix: update outdated Predibase endpoint URL in Python client README

### DIFF
--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -69,7 +69,7 @@ Example:
 ```python
 from lorax import Client
 
-endpoint_url = f"https://api.app.predibase.com/v1/llms/{llm_deployment_name}"
+endpoint_url = f"https://serving.app.predibase.com/{predibase_tenant_short_code}/deployments/v2/llms/{llm_deployment_name}"
 headers = {
     "Authorization": f"Bearer {api_token}"
 }


### PR DESCRIPTION
## Problem

The `endpoint_url` in `clients/python/README.md` under the Predibase Inference Endpoints section uses the old URL pattern:
```
https://api.app.predibase.com/v1/llms/{llm_deployment_name}
```

The correct URL pattern (as documented at loraexchange.ai) is:
```
https://serving.app.predibase.com/{predibase_tenant_short_code}/deployments/v2/llms/{llm_deployment_name}
```

## Fix

Updated the endpoint URL to match the current Predibase API.

Fixes #775