### PR TITLE
fix: make AlternativeToken.logprob optional

### DIFF
--- a/clients/python/lorax/types.py
+++ b/clients/python/lorax/types.py
@@ -282,7 +282,7 @@ class AlternativeToken(BaseModel):
     # Token text
     text: str
     # Logprob
-    logprob: float
+    logprob: Optional[float] = None
 
 
 # Generated tokens


### PR DESCRIPTION
## Problem

When using `return_k_alternatives`, the server can return `None` for `logprob` in alternative tokens. This causes a Pydantic `ValidationError` because `AlternativeToken.logprob` is typed as `float` instead of `Optional[float]`.

## Fix

Change `logprob: float` to `logprob: Optional[float] = None` in the `AlternativeToken` model, consistent with how `Token.logprob` and `InputToken.logprob` are already typed.

Fixes #764