### PR TITLE
feat(router): support OpenAI-compatible max_completion_tokens alias

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -672,6 +672,11 @@ struct ChatCompletionRequest {
     top_p: Option<f32>,
     n: Option<i32>,
     max_tokens: Option<i32>,
+    /// OpenAI-compatible alias for `max_tokens`. Per the OpenAI Chat Completions
+    /// API, `max_tokens` is deprecated in favor of `max_completion_tokens`. When
+    /// both are provided, `max_tokens` takes precedence to preserve existing
+    /// behavior.
+    max_completion_tokens: Option<i32>,
     #[serde(default)]
     stop: Vec<String>,
     stream: Option<bool>,
@@ -724,6 +729,7 @@ impl ChatCompletionRequest {
         let ChatCompletionRequest {
             model,
             max_tokens,
+            max_completion_tokens,
             messages,
             seed,
             stop,
@@ -837,7 +843,7 @@ impl ChatCompletionRequest {
                     top_p,
                     typical_p: None,
                     do_sample,
-                    max_new_tokens: max_tokens.map(|x| x as u32),
+                    max_new_tokens: max_tokens.or(max_completion_tokens).map(|x| x as u32),
                     return_full_text: None,
                     stop,
                     truncate: None,


### PR DESCRIPTION
## Problem

Closes #763.

OpenAI [deprecated](https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens) `max_tokens` in favor of `max_completion_tokens` on the Chat Completions API. Recent versions of LangChain and LiteLLM (and any client built against the current OpenAI SDK) emit only `max_completion_tokens`. lorax dropped this field via the `..` rest-pattern in `try_into_generate`, leaving `max_new_tokens` unset — generation then ran to the model's internal default cap, not what the caller asked for.

## Fix

Add `max_completion_tokens: Option<i32>` to `ChatCompletionRequest` and prefer `max_tokens` when both are present:

```rust
max_new_tokens: max_tokens.or(max_completion_tokens).map(|x| x as u32),
```

`max_tokens` wins on conflict so that requests already specifying both keep their existing behavior — only requests that send `max_completion_tokens` *alone* see a behavior change (which is the bug fix).

The legacy `/v1/completions` endpoint is intentionally untouched: the OpenAI text-completions API still uses `max_tokens`, so `CompletionRequest` does not need the alias.

## Scope

- 3 logical changes in `router/src/lib.rs` (one struct field + 1-line destructure + 1-line `.or(...)`).
- No changes to the gRPC schema, model server, or scheduler.
- No new dependencies.

## Test plan

- [ ] CI cargo build/check on the router crate.
- Reasoning: pure additive Serde field + `Option::or` — no semantic change for callers that only send `max_tokens`.
- After merge, a request sending only `{"max_completion_tokens": N, ...}` to `/v1/chat/completions` should now respect `N` instead of running to the model's default cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
