### PR TITLE
Add HTTP status codes to docs

### DIFF
--- a/docs/http_status_codes/http_status.md
+++ b/docs/http_status_codes/http_status.md
@@ -1,92 +1,52 @@
-# HTTP Status Codes Reference
+# HTTP Status Codes
 
-When using Lorax, you may sometimes receive confusing HTTP messages.  
-Refer to this file for definitions of HTTP status codes.
+The LoRAX API uses standard HTTP status codes to indicate the success or failure of requests. Below is a list of all status codes returned by LoRAX and what they mean.
 
----
+## Success
 
-## 1xx: Informational Responses
+| Code | Description |
+|------|-------------|
+| 200 OK | The request was successful. The response body contains the generated text, embeddings, or classification results. |
 
-- **100 Continue**: The initial part of the request was received, and the client can continue.
-- **101 Switching Protocols**: The server is switching protocols as requested.
-- **102 Processing**: The server is processing the request but has not completed it yet (WebDAV).
-- **103 Early Hints**: Used to return some response headers before the final HTTP message.
+## Client Errors
 
----
+| Code | Description |
+|------|-------------|
+| 400 Bad Request | The request contains invalid input. For example, a non-string or non-array value was provided where a string or array was expected. |
+| 404 Not Found | The requested resource could not be found. This may occur if no fast tokenizer is available for the requested model on the `/tokenize` endpoint. |
+| 422 Unprocessable Entity | Input validation failed. This can happen when required parameters are missing, parameters have invalid values, the input is empty, or chat template rendering fails. |
+| 429 Too Many Requests | The model is currently overloaded. The server is processing too many requests and cannot accept more at this time. Retry the request after a short delay. |
 
-## 2xx: Success
+## Server Errors
 
-- **200 OK**: The request was successful.
-- **201 Created**: The request succeeded, and a resource was created.
-- **202 Accepted**: The request has been accepted for processing, but not completed.
-- **203 Non-Authoritative Information**: The returned meta-information is not from the origin server.
-- **204 No Content**: The server successfully processed the request but returned no content.
-- **205 Reset Content**: The client should reset the document view.
-- **206 Partial Content**: The server is delivering only part of the resource due to a range header sent by the client.
-- **207 Multi-Status**: Conveys multiple status codes for a single request (WebDAV).
-- **208 Already Reported**: The members of a DAV binding have already been enumerated (WebDAV).
-- **226 IM Used**: The server has fulfilled a GET request for the resource (HTTP Delta Encoding).
+| Code | Description |
+|------|-------------|
+| 424 Failed Dependency | An upstream error occurred during generation. The request was accepted but the inference engine failed to produce a result. |
+| 500 Internal Server Error | The server encountered an unexpected condition. This may indicate incomplete generation (the stream ended prematurely), embedding failure, or classification failure. |
+| 503 Service Unavailable | The service is temporarily unavailable. The health check failed, indicating the server is not ready to accept requests. |
 
----
+## Endpoint-Specific Status Codes
 
-## 3xx: Redirection
+| Endpoint | Method | Status Codes |
+|----------|--------|--------------|
+| `/generate` | POST | 200, 422, 424, 429, 500 |
+| `/generate_stream` | POST | 200, 422, 424, 429, 500 |
+| `/v1/chat/completions` | POST | 200, 422, 424, 429, 500 |
+| `/v1/completions` | POST | 200, 422, 424, 429, 500 |
+| `/v1/embeddings` | POST | 200, 400, 500 |
+| `/embed` | POST | 200, 500 |
+| `/classify` | POST | 200, 500 |
+| `/tokenize` | POST | 200, 404 |
+| `/health` | GET | 200, 503 |
+| `/info` | GET | 200 |
+| `/metrics` | GET | 200 |
 
-- **300 Multiple Choices**: Multiple options for the resource are available.
-- **301 Moved Permanently**: The URL of the requested resource has been permanently changed.
-- **302 Found**: The resource resides temporarily under a different URL.
-- **303 See Other**: The response to the request can be found under another URL.
-- **304 Not Modified**: Indicates that the cached version is still valid.
-- **305 Use Proxy**: The requested resource must be accessed through a proxy (deprecated).
-- **306 (Unused)**: Previously used, but no longer in use.
-- **307 Temporary Redirect**: The resource temporarily resides under a different URL, and the method used should not be changed.
-- **308 Permanent Redirect**: The resource is now permanently located at another URL.
+## Error Response Format
 
----
+All error responses follow this format:
 
-## 4xx: Client Errors
-
-- **400 Bad Request**: The request cannot be fulfilled due to bad syntax.
-- **401 Unauthorized**: Authentication is required and has failed or has not been provided.
-- **402 Payment Required**: Reserved for future use.
-- **403 Forbidden**: The request was valid, but the server is refusing action.
-- **404 Not Found**: The requested resource could not be found.
-- **405 Method Not Allowed**: The request method is not supported for the requested resource.
-- **406 Not Acceptable**: The requested resource is capable of generating only unacceptable content.
-- **407 Proxy Authentication Required**: The client must authenticate itself with the proxy.
-- **408 Request Timeout**: The server timed out waiting for the request.
-- **409 Conflict**: Indicates a request conflict with the current state of the server.
-- **410 Gone**: The resource is no longer available and will not be available again.
-- **411 Length Required**: The server refuses to accept the request without a valid `Content-Length` header.
-- **412 Precondition Failed**: The server does not meet one of the preconditions set by the client.
-- **413 Payload Too Large**: The request entity is larger than the server is willing or able to process.
-- **414 URI Too Long**: The URI provided was too long for the server to process.
-- **415 Unsupported Media Type**: The media format of the requested data is not supported by the server.
-- **416 Range Not Satisfiable**: The range specified by the `Range` header field cannot be fulfilled.
-- **417 Expectation Failed**: The server cannot meet the requirements of the `Expect` header field.
-- **418 I'm a Teapot**: A playful response defined in RFC 2324 (April Fools').
-- **421 Misdirected Request**: The request was directed to a server that is unable to produce a response.
-- **422 Unprocessable Entity**: The request was well-formed but unable to be followed due to semantic errors (WebDAV).
-- **423 Locked**: The resource being accessed is locked (WebDAV).
-- **424 Failed Dependency**: The request failed due to failure of a previous request (WebDAV).
-- **425 Too Early**: The server is unwilling to risk processing a request that might be replayed.
-- **426 Upgrade Required**: The client should switch to a different protocol.
-- **428 Precondition Required**: The origin server requires the request to be conditional.
-- **429 Too Many Requests**: The user has sent too many requests in a given amount of time.
-- **431 Request Header Fields Too Large**: The server refuses to process the request due to large headers.
-- **451 Unavailable For Legal Reasons**: The resource is unavailable due to legal reasons.
-
----
-
-## 5xx: Server Errors
-
-- **500 Internal Server Error**: A generic error occurred on the server.
-- **501 Not Implemented**: The server does not recognize the request method.
-- **502 Bad Gateway**: The server received an invalid response from the upstream server.
-- **503 Service Unavailable**: The server is not ready to handle the request.
-- **504 Gateway Timeout**: The upstream server failed to send a request in time.
-- **505 HTTP Version Not Supported**: The server does not support the HTTP protocol version.
-- **506 Variant Also Negotiates**: The server has an internal configuration error.
-- **507 Insufficient Storage**: The server is unable to store the representation (WebDAV).
-- **508 Loop Detected**: The server detected an infinite loop while processing the request (WebDAV).
-- **510 Not Extended**: Further extensions to the request are required.
-- **511 Network Authentication Required**: The client needs to authenticate to gain network access.
+```json
+{
+  "error": "A human-readable error message",
+  "error_type": "machine_readable_error_type"
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Contributing to LoRAX:
           - Contributing to LoRAX: guides/contributing/index.md
           - Development Environment: guides/contributing/development_env.md
+      - HTTP Status Codes: http_status_codes/
   #     - GPUs: guides/gpus.md
   #     - Fine-Tuning: guides/fine_tuning.md
   #     - Memory Management: guides/memory_management.md


### PR DESCRIPTION
This PR adds LoRAX-specific HTTP status code documentation.

- Replaced the generic HTTP status reference with LoRAX-specific codes and descriptions
- Documents all status codes returned by each API endpoint
- Includes error types and retry guidance
- Added the page to the navigation

Fixes #481