### PR TITLE
Reject unknown fields from native API request bodies

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -329,6 +329,7 @@ fn default_parameters() -> GenerateParameters {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct GenerateRequest {
     #[schema(example = "My name is Olivier and I")]
     pub inputs: String,
@@ -347,6 +348,7 @@ fn default_true() -> bool {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct CompatGenerateRequest {
     #[schema(example = "My name is Olivier and I")]
     pub inputs: String,
@@ -374,6 +376,7 @@ impl From<CompatGenerateRequest> for GenerateRequest {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct TokenizeRequest {
     #[schema(example = "My name is Olivier and I")]
     pub inputs: String,
@@ -1156,6 +1159,7 @@ impl Default for EmbedParameters {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 struct EmbedRequest {
     inputs: String,
     #[serde(default)]
@@ -1184,6 +1188,7 @@ impl std::fmt::Display for StringOrVec {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 struct CompatEmbedRequest {
     input: StringOrVec,
     #[allow(dead_code)]
@@ -1211,16 +1216,19 @@ struct CompatEmbedding {
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 struct ClassifyRequest {
     inputs: String,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 struct BatchClassifyRequest {
     inputs: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 struct BatchEmbedRequest {
     inputs: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
### What

Adds `#[serde(deny_unknown_fields)]` to the **lorax-native** HTTP request body structs in `router/src/lib.rs`, so a request containing an unknown or misplaced field fails with a clear deserialization/validation error instead of being silently ignored.

Closes #478.

### Why

Per #478, unknown top-level fields are currently dropped silently. A common failure mode is putting `api_token` at the top level instead of inside `parameters`, which then surfaces as a confusing "access denied" instead of a validation error. Rejecting unknown fields makes these mistakes obvious at the request boundary.

### Structs covered (8 native request bodies)

- `GenerateRequest`, `CompatGenerateRequest`, `TokenizeRequest`
- `EmbedRequest`, `CompatEmbedRequest`
- `ClassifyRequest`, `BatchClassifyRequest`, `BatchEmbedRequest`

### Deliberately NOT covered

- **`ChatCompletionRequest` / `CompletionRequest`** — these back the OpenAI-compatible `/v1/chat/completions` and `/v1/completions` endpoints, which conventionally tolerate unknown fields for forward-compat with the OpenAI spec. These structs already follow that convention (several `#[allow(dead_code)]` accept-but-ignore fields), and locking them down would reject standard OpenAI params lorax hasn't implemented yet (e.g. `stream_options`, `parallel_tool_calls`, `max_completion_tokens`, `top_logprobs`) and break real OpenAI SDK clients. Happy to include them if you'd prefer strictness there too.
- **`JsonSchemaTool`** — uses `#[serde(flatten)]`, which serde does not allow together with `deny_unknown_fields` (it's the only `flatten` in the file, and it isn't a request body).

### Notes

- Scope is the top-level request bodies, which covers the motivating case in #478. Nested parameter structs (e.g. `GenerateParameters`) could be a follow-up.
- I don't have a local Rust toolchain to run `cargo build`/`test`; the change is a pure serde container-attribute addition with the one `flatten` struct excluded, so I'm relying on CI to confirm.
